### PR TITLE
[dart_lsc] Support 1.0.0 version of stable dependencies

### DIFF
--- a/carp_mobile_sensing/CHANGELOG.md
+++ b/carp_mobile_sensing/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.4
+
+* Support 1.0.0 version of stable dependencies. ([dart_lsc](http://github.com/amirh/dart_lsc))
+
 ## 0.6.3
 * moved the `connectivity` sampling package to an external [`carp_connectivity_package`](https://pub.dev/packages/carp_connectivity_package) 
   due to [issue#46](https://github.com/cph-cachet/carp.sensing-flutter/issues/46).

--- a/carp_mobile_sensing/pubspec.yaml
+++ b/carp_mobile_sensing/pubspec.yaml
@@ -1,6 +1,6 @@
 name: carp_mobile_sensing
 description: Mobile Sensing Framework for Flutter. A software framework for collecting sensor data from the phone and attached wearable devices via probes. Can be extended.
-version: 0.6.3
+version: 0.6.4
 author:  CACHET Team <cph.cachet@gmail.com>
 homepage: https://github.com/cph-cachet/carp.sensing-flutter/tree/master/carp_mobile_sensing
 
@@ -24,7 +24,7 @@ dependencies:
 
   # probe-dependent plugins
   sensors: ^0.4.0
-  battery: ^0.3.0
+  battery: '>=0.3.0 <2.0.0'
   stats: ^0.2.0           # For calculating statistics, ex LightProbe
 
   # the CACHET plugins
@@ -45,4 +45,3 @@ dev_dependencies:
 
 # The following section is specific to Flutter.
 flutter:
-


### PR DESCRIPTION
This should be a safe change, for more details see: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0

This change was auto generated by [dart_lsc](https://github.com/amirh/dart_lsc).