### PR TITLE
Removed unnecesary JSON object from CreateStudyDeployment request

### DIFF
--- a/carp_core/lib/carp_deployment/carp_core_deployment.g.dart
+++ b/carp_core/lib/carp_deployment/carp_core_deployment.g.dart
@@ -11,12 +11,12 @@ MasterDeviceDeployment _$MasterDeviceDeploymentFromJson(
   return MasterDeviceDeployment(
     deviceDescriptor: json['deviceDescriptor'] == null
         ? null
-        : MasterDeviceDescriptor
-            .fromJson(json['deviceDescriptor'] as Map<String, dynamic>),
+        : MasterDeviceDescriptor.fromJson(
+            json['deviceDescriptor'] as Map<String, dynamic>),
     configuration: json['configuration'] == null
         ? null
-        : DeviceRegistration
-            .fromJson(json['configuration'] as Map<String, dynamic>),
+        : DeviceRegistration.fromJson(
+            json['configuration'] as Map<String, dynamic>),
     connectedDevices: (json['connectedDevices'] as List)
         ?.map((e) => e == null
             ? null
@@ -334,16 +334,13 @@ CreateStudyDeployment _$CreateStudyDeploymentFromJson(
     json['protocol'] == null
         ? null
         : StudyProtocol.fromJson(json['protocol'] as Map<String, dynamic>),
-  )
-    ..$type = json[r'$type'] as String
-    ..studyDeploymentId = json['studyDeploymentId'] as String;
+  )..$type = json[r'$type'] as String;
 }
 
 Map<String, dynamic> _$CreateStudyDeploymentToJson(
         CreateStudyDeployment instance) =>
     <String, dynamic>{
       r'$type': instance.$type,
-      'studyDeploymentId': instance.studyDeploymentId,
       'protocol': instance.protocol,
     };
 
@@ -384,8 +381,8 @@ RegisterDevice _$RegisterDeviceFromJson(Map<String, dynamic> json) {
     json['deviceRoleName'] as String,
     json['registration'] == null
         ? null
-        : DeviceRegistration
-            .fromJson(json['registration'] as Map<String, dynamic>),
+        : DeviceRegistration.fromJson(
+            json['registration'] as Map<String, dynamic>),
   )..$type = json[r'$type'] as String;
 }
 

--- a/carp_core/lib/carp_deployment/infrastructure/deployment_request.dart
+++ b/carp_core/lib/carp_deployment/infrastructure/deployment_request.dart
@@ -35,6 +35,9 @@ abstract class DeploymentServiceRequest extends ServiceRequest {
 class CreateStudyDeployment extends DeploymentServiceRequest {
   StudyProtocol protocol;
 
+  @JsonKey(ignore: true)
+  String studyDeploymentId;
+
   CreateStudyDeployment(this.protocol) : super();
 
   Function get fromJsonFunction => _$CreateStudyDeploymentFromJson;

--- a/carp_core/lib/carp_protocols/carp_core_protocols.g.dart
+++ b/carp_core/lib/carp_protocols/carp_core_protocols.g.dart
@@ -533,8 +533,8 @@ ScheduledTrigger _$ScheduledTriggerFromJson(Map<String, dynamic> json) {
         : TimeOfDay.fromJson(json['time'] as Map<String, dynamic>),
     recurrenceRule: json['recurrenceRule'] == null
         ? null
-        : RecurrenceRule
-            .fromJson(json['recurrenceRule'] as Map<String, dynamic>),
+        : RecurrenceRule.fromJson(
+            json['recurrenceRule'] as Map<String, dynamic>),
   )..$type = json[r'$type'] as String;
 }
 


### PR DESCRIPTION
The object was used by other requests from the deployment subsystem, but not for this one, leading to a serialization error.