### PR TITLE
Fixed the two } in the resource manager

### DIFF
--- a/backends/carp_backend/lib/carp_resource_manager.dart
+++ b/backends/carp_backend/lib/carp_resource_manager.dart
@@ -189,7 +189,7 @@ class CarpResourceManager
   Future<String> _cacheLocalizationFilename(Locale locale) async {
     if (_cacheLocalizationPath == null) {
       final directory = await Directory(
-              '${await Settings().carpBasePath}}/$LOCALIZATION_PATH')
+              '${await Settings().carpBasePath}/$LOCALIZATION_PATH')
           .create(recursive: true);
       _cacheLocalizationPath = directory.path;
     }


### PR DESCRIPTION
This was throwing an error

```flutter: [CAMS WARNING]  Failed to read localization from cache of type 'da' - FileSystemException: Cannot open file, path = '/var/mobile/Containers/Data/Application/..../Documents/carp}/localizations/da.json' (OS Error: No such file or directory, errno = 2)```

which was caused by a typo in `CarpResourceManager`