### PR TITLE
Update after 'Save the actual measurement range in app_usage' cph-cachet/flutter-plugins

### DIFF
--- a/packages/carp_apps_package/lib/app_probes.dart
+++ b/packages/carp_apps_package/lib/app_probes.dart
@@ -52,11 +52,27 @@ class AppUsageProbe extends DatumProbe {
         'Collecting app usage - start: ${start.toUtc()}, end: ${end.toUtc()}');
     List<AppUsageInfo> infos = await AppUsage.getAppUsage(start, end);
 
+
+    // Create maps for several sets of information
     Map<String, int> usage = {};
+    Map<String, DateTime> startRange = {};
+    Map<String, DateTime> stopRange = {};
+    Map<String, DateTime> lastUseForeground = {};
+
+    // use full package name
     for (AppUsageInfo inf in infos) {
-      usage[inf.appName] = inf.usage.inSeconds;
+      usage[inf.packageName] = inf.usage.inSeconds;
+      startRange[inf.packageName] = inf.startDate;
+      stopRange[inf.packageName] = inf.endDate;
+      lastUseForeground[inf.packageName] = inf.lastForeground;
     }
 
-    return AppUsageDatum(start.toUtc(), end.toUtc())..usage = usage;
+    AppUsageDatum toReturn=(AppUsageDatum(start.toUtc(), end.toUtc())..usage = usage);
+    toReturn.stopRange=stopRange;
+    toReturn.startRange=startRange;
+    toReturn.lastUseForeground=lastUseForeground;
+    return toReturn;
   }
+
+
 }

--- a/packages/carp_apps_package/lib/apps.g.dart
+++ b/packages/carp_apps_package/lib/apps.g.dart
@@ -35,7 +35,17 @@ AppUsageDatum _$AppUsageDatumFromJson(Map<String, dynamic> json) =>
     )
       ..id = json['id'] as String?
       ..timestamp = DateTime.parse(json['timestamp'] as String)
-      ..usage = Map<String, int>.from(json['usage'] as Map);
+      ..usage = Map<String, int>.from(json['usage'] as Map)
+      ..startRange = (json['start_range'] as Map<String, dynamic>).map(
+        (k, e) => MapEntry(k, DateTime.parse(e as String)),
+      )
+      ..stopRange = (json['stop_range'] as Map<String, dynamic>).map(
+        (k, e) => MapEntry(k, DateTime.parse(e as String)),
+      )
+      ..lastUseForeground =
+          (json['last_use_foreground'] as Map<String, dynamic>).map(
+        (k, e) => MapEntry(k, DateTime.parse(e as String)),
+      );
 
 Map<String, dynamic> _$AppUsageDatumToJson(AppUsageDatum instance) {
   final val = <String, dynamic>{};
@@ -51,5 +61,11 @@ Map<String, dynamic> _$AppUsageDatumToJson(AppUsageDatum instance) {
   val['start'] = instance.start.toIso8601String();
   val['end'] = instance.end.toIso8601String();
   val['usage'] = instance.usage;
+  val['start_range'] =
+      instance.startRange.map((k, e) => MapEntry(k, e.toIso8601String()));
+  val['stop_range'] =
+      instance.stopRange.map((k, e) => MapEntry(k, e.toIso8601String()));
+  val['last_use_foreground'] = instance.lastUseForeground
+      .map((k, e) => MapEntry(k, e.toIso8601String()));
   return val;
 }

--- a/packages/carp_apps_package/lib/apps_datum.dart
+++ b/packages/carp_apps_package/lib/apps_datum.dart
@@ -37,6 +37,9 @@ class AppUsageDatum extends Datum {
 
   /// A map of names of apps and their usage in seconds.
   Map<String, int> usage = {};
+  Map<String,DateTime> startRange={};
+  Map<String,DateTime>stopRange={};
+  Map<String,DateTime>lastUseForeground={};
 
   AppUsageDatum(this.start, this.end) : super();
 
@@ -48,5 +51,5 @@ class AppUsageDatum extends Datum {
 
   @override
   String toString() =>
-      '${super.toString()}, start: $start, end: $end, usage: $usage';
+      '${super.toString()}, start: $start, end: $end, stopRange: $stopRange, startRange: $startRange , usage: $usage, lastUseForeground: $lastUseForeground';
 }


### PR DESCRIPTION
The big problem with the previous version is that the range in which the app usage was measured was not saved. This range cannot be set and therefore is not the same as the input time range (see https://github.com/cph-cachet/flutter-plugins/issues/592). Additionally some extra information on appusage is gathered (last time app was in foreground).

First of course the pull request from https://github.com/cph-cachet/flutter-plugins/pull/624 needs to be accepted. After that there probably needs to be a change in pubspec.yaml.

This pull requests makes sure that the range for each app is saved. Instead of one, there are now 4 maps in the output. 

```
  Map<String, int> usage = {};
  Map<String,DateTime> startRange={};
  Map<String,DateTime>stopRange={};
  Map<String,DateTime>lastUseForeground={};
```

The maps go from the string of the package name to the following:
usage : total time in foreground
startRange: The start of the range
stopRange: The end of the range
lastUseForeground: The last time the app was in foreground

I'm not sure if 4 separate maps is the best way of outputting the information though. 

Additionally, the maps now have the full package name. Only taking the last part doesn't give enough information for all apps. Examples:

- com.brave.browser
- com.instagram.android
- com.imdb.mobile

I think I did the automatic JsonSerializableGenerator correct, but I have no experience with this...
