### PR TITLE
Add timeZoneName

### DIFF
--- a/carp_core/lib/carp_data/carp_core_data.g.dart
+++ b/carp_core/lib/carp_data/carp_core_data.g.dart
@@ -46,6 +46,7 @@ DataPointHeader _$DataPointHeaderFromJson(Map<String, dynamic> json) =>
       endTime: json['end_time'] == null
           ? null
           : DateTime.parse(json['end_time'] as String),
+      timeZoneName: json['time_zone_name'] as String?,
     )..uploadTime = json['upload_time'] == null
         ? null
         : DateTime.parse(json['upload_time'] as String);
@@ -66,6 +67,7 @@ Map<String, dynamic> _$DataPointHeaderToJson(DataPointHeader instance) {
   writeNotNull('upload_time', instance.uploadTime?.toIso8601String());
   writeNotNull('start_time', instance.startTime?.toIso8601String());
   writeNotNull('end_time', instance.endTime?.toIso8601String());
+  writeNotNull('time_zone_name', instance.timeZoneName);
   val['data_format'] = instance.dataFormat;
   return val;
 }

--- a/carp_core/lib/carp_data/datapoint.dart
+++ b/carp_core/lib/carp_data/datapoint.dart
@@ -95,6 +95,7 @@ class DataPoint {
       DataPointHeader(
         dataFormat: data.format,
         startTime: DateTime.now().toUtc(),
+        timeZoneName: DateTime.now().timeZoneName,
       ),
       data);
 
@@ -136,6 +137,9 @@ class DataPointHeader {
   /// If this data point does not cover a period, [endTime] will be `null`.
   DateTime? endTime;
 
+  // Current time zone name of the device
+  String? timeZoneName;
+
   /// The data format. See [DataFormat] and [NameSpace].
   DataFormat dataFormat;
 
@@ -148,6 +152,7 @@ class DataPointHeader {
     this.triggerId,
     this.startTime,
     this.endTime,
+    this.timeZoneName,
   }) {
     // make sure that timestamps are in UTC
     if (startTime != null) startTime!.toUtc();


### PR DESCRIPTION
Adding time zone information to DataPointHeader. This is necessary if the data has to be linked to data outside of CARP context that is not in UTC time. The time zone is initiated when a DataPoint is created (together with startTime). 

Related to https://github.com/cph-cachet/carp.sensing-flutter/issues/301