### PR TITLE
Improve task and notification scheduling

### DIFF
--- a/carp_mobile_sensing/CHANGELOG.md
+++ b/carp_mobile_sensing/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 1.7.0
+
+- Refactor task and notification enqueueing process:
+  - Move from sequential scheduling for each TaskControl to buffering tasks in AppTaskController.
+  - Buffered tasks are sorted by time and scheduled in batches based on platform limits (iOS and Android notification limits).
+- Enhance consistency in task scheduling:
+  - Ensured all necessary tasks in the foreseeable future are queued.
+  - Prevent task and notification drops due to notification slot limitations.
+- Resolve issue with duplicate tasks being scheduled:
+  - Ensure tasks are stored in the database after being scheduled the first time.
+
 ## 1.6.1
 
 * improvement to removing studies (linked to issue [#283](https://github.com/cph-cachet/carp_studies_app/issues/283) in the CARP Studies App)

--- a/carp_mobile_sensing/lib/runtime/app_task_controller.dart
+++ b/carp_mobile_sensing/lib/runtime/app_task_controller.dart
@@ -152,8 +152,8 @@ class AppTaskController {
     }
   }
 
-  /// Buffer a particular task from a [TaskControl] for later scheduling.
-  /// The buffered tasks can later be enqueued using [enqueueBufferedTasks].
+  /// Buffer the [executor] originating from [taskControl] for later scheduling.
+  /// The buffered task executors is enqueued by calling [enqueueBufferedTasks].
   void buffer(
     AppTaskExecutor executor,
     TaskControl taskControl, {
@@ -185,7 +185,9 @@ class AppTaskController {
 
     var numberOfTasksToEnqueue =
         min(remainingNotifications, _userTaskBuffer.length);
-    // being mindful of the OS limitations, only schedule however many tasks as remaining notification slots
+
+    // Being mindful of the OS limitations, only schedule however many
+    // tasks as remaining notification slots
     List<UserTaskBufferItem> toEnqueue =
         _userTaskBuffer.sublist(0, numberOfTasksToEnqueue);
 
@@ -200,11 +202,11 @@ class AppTaskController {
       );
     }
 
-    // discard the tasks that we couldn't queue, they will be re-queued later
+    // Discard the tasks that we couldn't queue, they will be re-queued later.
     _userTaskBuffer.clear();
 
-    // persist the tasks that were just enqueued
-    SmartPhoneClientManager().deactivate();
+    // Persist the tasks that were just enqueued
+    SmartPhoneClientManager().save();
   }
 
   /// De-queue (remove) an [UserTask] from the [userTasks].

--- a/carp_mobile_sensing/lib/runtime/app_task_controller.dart
+++ b/carp_mobile_sensing/lib/runtime/app_task_controller.dart
@@ -24,7 +24,8 @@ class AppTaskController {
   /// and which are planned to trigger in the future.
   List<UserTask> get userTasks => _userTaskMap.values.toList();
 
-  List<UserTaskBufferItem> _userTaskBuffer = [];
+  /// A buffer of tasks that are not yet scheduled.
+  final List<UserTaskBufferItem> _userTaskBuffer = [];
 
   /// The queue of [UserTask]s that the user need to attend to.
   List<UserTask> get userTaskQueue => _userTaskMap.values

--- a/carp_mobile_sensing/lib/runtime/client_manager.dart
+++ b/carp_mobile_sensing/lib/runtime/client_manager.dart
@@ -235,6 +235,14 @@ class SmartPhoneClientManager extends SmartphoneClient
     }
   }
 
+  /// Persistently save information related to this client manger.
+  /// Typically used for later resuming when app is restarted. See [resume].
+  Future<void> save() async {
+    for (var study in studies) {
+      await getStudyRuntime(study)?.saveDeployment();
+    }
+  }
+
   /// Called when this client manager is being (re-)activated by the OS.
   ///
   /// Implementations of this method should start with a call to the inherited
@@ -250,11 +258,7 @@ class SmartPhoneClientManager extends SmartphoneClient
   /// method, as in `super.deactivate()`.
   @protected
   @mustCallSuper
-  Future<void> deactivate() async {
-    for (var study in studies) {
-      await getStudyRuntime(study)?.saveDeployment();
-    }
-  }
+  Future<void> deactivate() async => await save();
 
   /// Start all studies in this client manager.
   void start() {

--- a/carp_mobile_sensing/lib/runtime/executors/deployment_executor.dart
+++ b/carp_mobile_sensing/lib/runtime/executors/deployment_executor.dart
@@ -59,6 +59,18 @@ class SmartphoneDeploymentExecutor
     return true;
   }
 
+  /// Run the deployment, and after the deployment is finished, enqueue all buffered tasks.
+  @override
+  Future<bool> onStart() async {
+    bool val = await super.onStart();
+
+    await AppTaskController().enqueueBufferedTasks();
+    debug(
+        '$runtimeType - Deployment finished - ${await SmartPhoneClientManager().notificationController?.pendingNotificationRequestsCount} notifications are currently pending.');
+
+    return val;
+  }
+
   @override
   Future<void> onDispose() async {
     await super.onDispose();

--- a/carp_mobile_sensing/lib/runtime/executors/task_control_executors.dart
+++ b/carp_mobile_sensing/lib/runtime/executors/task_control_executors.dart
@@ -156,35 +156,31 @@ class AppTaskControlExecutor extends TaskControlExecutor {
 
   @override
   Future<bool> onStart() async {
+    debug(
+        '$runtimeType - ${taskControl.taskName} hasBeenScheduledUntil ${taskControl.hasBeenScheduledUntil}');
     final from = taskControl.hasBeenScheduledUntil ?? DateTime.now();
-    final to = from.add(const Duration(days: 10)); // look 10 days ahead
-    final schedule = triggerExecutor.getSchedule(from, to, 10);
+    final to =
+        DateTime.now().add(const Duration(days: 15)); // look 15 days ahead
+    // get all the instances where the task should be scheduled in the given range
+    final schedule = triggerExecutor.getSchedule(from, to);
 
     if (schedule.isEmpty) {
       // Stop since the schedule is empty and there is not more to schedule.
       stop();
     } else {
-      // Enqueue the first 6 (max) app tasks in the future
-      var remainingNotifications =
-          NotificationController.PENDING_NOTIFICATION_LIMIT -
-              (await SmartPhoneClientManager()
-                      .notificationController
-                      ?.pendingNotificationRequestsCount ??
-                  0);
-      remainingNotifications = min(remainingNotifications, 6);
+      info(
+          '$runtimeType Enqueuing ${schedule.length} app tasks ($schedule) for task ${taskExecutor.task.name}');
+
       Iterator<DateTime> it = schedule.iterator;
-      var count = 0;
       DateTime current = DateTime.now();
-      while (it.moveNext() && count++ < remainingNotifications) {
+      while (it.moveNext()) {
         current = it.current;
-        await AppTaskController().enqueue(
+        AppTaskController().buffer(
           taskExecutor,
+          taskControl,
           triggerTime: current,
         );
       }
-
-      // Save timestamp
-      taskControl.hasBeenScheduledUntil = current;
 
       // Now stop since the schedule has all been enqueued.
       stop();

--- a/carp_mobile_sensing/lib/runtime/executors/task_control_executors.dart
+++ b/carp_mobile_sensing/lib/runtime/executors/task_control_executors.dart
@@ -157,10 +157,9 @@ class AppTaskControlExecutor extends TaskControlExecutor {
   @override
   Future<bool> onStart() async {
     debug(
-        '$runtimeType - ${taskControl.taskName} hasBeenScheduledUntil ${taskControl.hasBeenScheduledUntil}');
+        '$runtimeType - ${taskControl.taskName} hasBeenScheduledUntil: ${taskControl.hasBeenScheduledUntil}');
     final from = taskControl.hasBeenScheduledUntil ?? DateTime.now();
-    final to =
-        DateTime.now().add(const Duration(days: 15)); // look 15 days ahead
+    final to = DateTime.now().add(const Duration(days: 15)); // 15 days ahead
     // get all the instances where the task should be scheduled in the given range
     final schedule = triggerExecutor.getSchedule(from, to);
 
@@ -169,7 +168,7 @@ class AppTaskControlExecutor extends TaskControlExecutor {
       stop();
     } else {
       info(
-          '$runtimeType Enqueuing ${schedule.length} app tasks ($schedule) for task ${taskExecutor.task.name}');
+          '$runtimeType Buffering ${schedule.length} app tasks ($schedule) for task ${taskExecutor.task.name}');
 
       Iterator<DateTime> it = schedule.iterator;
       DateTime current = DateTime.now();
@@ -197,6 +196,5 @@ class AppTaskControlExecutor extends TaskControlExecutor {
   }
 
   @override
-  Future<bool> onStop() async =>
-      true; // do nothing - this executor is never stopped
+  Future<bool> onStop() async => true; // do nothing
 }

--- a/carp_mobile_sensing/lib/runtime/notification/notification_controller.dart
+++ b/carp_mobile_sensing/lib/runtime/notification/notification_controller.dart
@@ -22,8 +22,8 @@ part of '../runtime.dart';
 /// and [scheduleRecurrentNotifications] methods, which
 /// creates an immediate, scheduled, or recurrent notification, respectively.
 abstract class NotificationController {
-  /// The upper limit of scheduled notification on iOS.
-  static const PENDING_NOTIFICATION_LIMIT = 64;
+  /// The upper limit of scheduled notification, platform dependent.
+  static final pendingNotificationLimit = Platform.isIOS ? 64 : 500;
 
   /// The id of the notification channel.
   static const CHANNEL_ID = 'carp_mobile_sensing_notifications';

--- a/carp_mobile_sensing/pubspec.yaml
+++ b/carp_mobile_sensing/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   system_info2: ^4.0.0
   async: ^2.11.0
   statistics: ^1.0.0
-  sample_statistics: ^0.1.3  
+  sample_statistics: ^0.2.0  
   path_provider: ^2.0.0
   sqflite: ^2.2.8                     # For local storage in SQLite DB
   archive: ^3.3.0

--- a/carp_mobile_sensing/pubspec.yaml
+++ b/carp_mobile_sensing/pubspec.yaml
@@ -1,6 +1,6 @@
 name: carp_mobile_sensing
 description: Mobile Sensing Framework for Flutter. A software framework for collecting sensor data from the phone and attached wearable devices via probes. Can be extended.
-version: 1.6.1
+version: 1.7.0
 homepage: https://github.com/cph-cachet/carp.sensing-flutter
 
 environment:


### PR DESCRIPTION
This PR contains a refactor to the way that tasks and notifications are enqueued.

Instead of going through each `TaskControl` and trying to schedule the tasks and notifications for each one after another, we now buffer the tasks to be enqueued in the `AppTaskController`. Once we have accumulated all the tasks from all `TaskControls`, we sort them by time and schedule the first N tasks depending on how many the platform allows us to (iOS and Android have limits for how many notifications can be scheduled).

This greatly improves the consistency of the task scheduler as we can now expect all the necessary tasks in the foreseeable future to be in the queue, whereas before tasks and notifications would be dropped if we ran out of notification slots.

This also resolves an issue with duplicate tasks being scheduled because they were not stored in the database after being scheduled the first time.