### PR TITLE
Upgrade of carp_context_package to better handle permissions + getting current location

### DIFF
--- a/apps/carp_mobile_sensing_app/README.md
+++ b/apps/carp_mobile_sensing_app/README.md
@@ -175,7 +175,7 @@ class StudyDeploymentViewModel {
   Stream<ExecutorState> get studyExecutorStateEvents =>
       bloc.sensing.controller!.executor.stateEvents;
 
-  /// Current state of the study executor (e.g., resumed, paused, ...)
+  /// Current state of the study executor (e.g., started, stopped, ...)
   ExecutorState get studyState => bloc.sensing.controller!.executor.state;
 
   /// Get all sensing events (i.e. all [Measurement] objects being collected).

--- a/apps/carp_mobile_sensing_app/analysis_options.yaml
+++ b/apps/carp_mobile_sensing_app/analysis_options.yaml
@@ -15,4 +15,4 @@ linter:
     cancel_subscriptions: true
     constant_identifier_names: false
     depend_on_referenced_packages: false
-    use_string_in_part_of_directives: false
+    use_string_in_part_of_directives: true

--- a/apps/carp_mobile_sensing_app/ios/Flutter/AppFrameworkInfo.plist
+++ b/apps/carp_mobile_sensing_app/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>11.0</string>
+  <string>12.0</string>
 </dict>
 </plist>

--- a/apps/carp_mobile_sensing_app/ios/Runner.xcodeproj/project.pbxproj
+++ b/apps/carp_mobile_sensing_app/ios/Runner.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
+		83B17C419358DCC14F4BF7D8 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE315FAA19E92C3CCA8E35CC /* Pods_Runner.framework */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
@@ -32,9 +33,12 @@
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
+		4AAD24F0DD03DFADC1E7F711 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		7A41852A33A3130B629E1847 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
+		8570FBD7F7AA5A6435D33A09 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
 		97C146EE1CF9000F007C117D /* Runner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Runner.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -42,6 +46,7 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		CE315FAA19E92C3CCA8E35CC /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D60047282A9FBF32003E312E /* Runner.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Runner.entitlements; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -50,12 +55,32 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				83B17C419358DCC14F4BF7D8 /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		38514E5E346850CE7E71DE31 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				CE315FAA19E92C3CCA8E35CC /* Pods_Runner.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		68D760C1B1DDB1C0BB6C2668 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				7A41852A33A3130B629E1847 /* Pods-Runner.debug.xcconfig */,
+				4AAD24F0DD03DFADC1E7F711 /* Pods-Runner.release.xcconfig */,
+				8570FBD7F7AA5A6435D33A09 /* Pods-Runner.profile.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
+			sourceTree = "<group>";
+		};
 		9740EEB11CF90186004384FC /* Flutter */ = {
 			isa = PBXGroup;
 			children = (
@@ -73,6 +98,8 @@
 				9740EEB11CF90186004384FC /* Flutter */,
 				97C146F01CF9000F007C117D /* Runner */,
 				97C146EF1CF9000F007C117D /* Products */,
+				68D760C1B1DDB1C0BB6C2668 /* Pods */,
+				38514E5E346850CE7E71DE31 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -107,12 +134,14 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
+				0CDFE076389EE989CE0F7AE8 /* [CP] Check Pods Manifest.lock */,
 				9740EEB61CF901F6004384FC /* Run Script */,
 				97C146EA1CF9000F007C117D /* Sources */,
 				97C146EB1CF9000F007C117D /* Frameworks */,
 				97C146EC1CF9000F007C117D /* Resources */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
+				223F58A645C142ABD194AEAF /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -129,7 +158,7 @@
 		97C146E61CF9000F007C117D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1430;
+				LastUpgradeCheck = 1510;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {
@@ -171,6 +200,45 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		0CDFE076389EE989CE0F7AE8 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		223F58A645C142ABD194AEAF /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -277,7 +345,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;
@@ -294,7 +362,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
-				DEVELOPMENT_TEAM = 8TB3T6MAZG;
+				DEVELOPMENT_TEAM = 59TCTNUBMQ;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -356,7 +424,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -405,7 +473,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;
@@ -448,7 +516,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
-				DEVELOPMENT_TEAM = 8TB3T6MAZG;
+				DEVELOPMENT_TEAM = 59TCTNUBMQ;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/apps/carp_mobile_sensing_app/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/apps/carp_mobile_sensing_app/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1430"
+   LastUpgradeVersion = "1510"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/apps/carp_mobile_sensing_app/ios/Runner.xcworkspace/contents.xcworkspacedata
+++ b/apps/carp_mobile_sensing_app/ios/Runner.xcworkspace/contents.xcworkspacedata
@@ -4,4 +4,7 @@
    <FileRef
       location = "group:Runner.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
 </Workspace>

--- a/apps/carp_mobile_sensing_app/ios/Runner/AppDelegate.swift
+++ b/apps/carp_mobile_sensing_app/ios/Runner/AppDelegate.swift
@@ -1,7 +1,7 @@
 import UIKit
 import Flutter
 import flutter_local_notifications
-import awesome_notifications
+// import awesome_notifications
 
 @UIApplicationMain
 @objc class AppDelegate: FlutterAppDelegate {
@@ -33,10 +33,10 @@ import awesome_notifications
     // From awesome_notifications -- see https://pub.dev/packages/awesome_notifications#-extra-ios-setup-for-background-actions
     // See example app - https://github.com/rafaelsetragni/awesome_notifications/blob/master/example/ios/Runner/AppDelegate.swift 
     // This function registers the desired plugins to be used within a notification background action
-    SwiftAwesomeNotificationsPlugin.setPluginRegistrantCallback { registry in          
-        SwiftAwesomeNotificationsPlugin.register(
-          with: registry.registrar(forPlugin: "io.flutter.plugins.awesomenotifications.AwesomeNotificationsPlugin")!)          
-    }
+    // SwiftAwesomeNotificationsPlugin.setPluginRegistrantCallback { registry in          
+    //     SwiftAwesomeNotificationsPlugin.register(
+    //       with: registry.registrar(forPlugin: "io.flutter.plugins.awesomenotifications.AwesomeNotificationsPlugin")!)          
+    // }
 
     GeneratedPluginRegistrant.register(with: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)

--- a/apps/carp_mobile_sensing_app/ios/Runner/Info.plist
+++ b/apps/carp_mobile_sensing_app/ios/Runner/Info.plist
@@ -26,22 +26,42 @@
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
-	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
-	<string>This app needs access to location when open and in the background.</string>
-	<key>NSLocationAlwaysUsageDescription</key>
-	<string>This app needs access to location when in the background.</string>
-	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>This app needs access to location when open.</string>
+
+	<!-- Permissions for Bluetooth -->
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>CARP uses bluetooth to connect to wearable devices</string>
+	<key>NSBluetoothPeripheralUsageDescription</key>
+	<string>CARP uses bluetooth to connect to wearable devices</string>
+	
+	<!-- Permissions for accessing `health` data -->
 	<key>NSHealthShareUsageDescription</key>
 	<string>We will sync your data with the Apple Health app to give you better insights</string>
 	<key>NSHealthUpdateUsageDescription</key>
-	<string>We will sync your data with the Apple Health app to give you better insights</string>	
+	<string>We will sync your data with the Apple Health app to give you better insights</string>
+
+	<!-- Permission options for the `location` group -->
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>The CARP app needs access to location when open and in the background.</string>
+	<key>NSLocationAlwaysUsageDescription</key>
+	<string>The CARP app needs access to location when in the background.</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>The CARP app needs access to location when open.</string>
+	<key>NSLocationUsageDescription</key>
+	<string>The CARP app needs access to location when open and in the background.</string>
+	
+	<key>NSMotionUsageDescription</key>
+	<string>The CARP app uses the motion system to detects activities such as walking and biking</string>
+
+	<key>NSMicrophoneUsageDescription</key>
+	<string>The CARP app uses the microphone to record ambient noise in the phone's environment</string>
+
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
 	<key>UIBackgroundModes</key>
 	<array>
+		<string>bluetooth-central</string>
 		<string>location</string>
-		<string>bluetooth-central</string>		
+		<string>processing</string>
 	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
@@ -50,15 +70,10 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationPortraitUpsideDown</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>

--- a/apps/carp_mobile_sensing_app/ios/Runner/Runner.entitlements
+++ b/apps/carp_mobile_sensing_app/ios/Runner/Runner.entitlements
@@ -5,6 +5,10 @@
 	<key>com.apple.developer.healthkit</key>
 	<true/>
 	<key>com.apple.developer.healthkit.access</key>
-	<array/>
+	<array>
+		<string>health-records</string>
+	</array>
+	<key>com.apple.developer.healthkit.background-delivery</key>
+	<true/>
 </dict>
 </plist>

--- a/apps/carp_mobile_sensing_app/lib/main.dart
+++ b/apps/carp_mobile_sensing_app/lib/main.dart
@@ -3,7 +3,6 @@ library mobile_sensing_app;
 import 'dart:async';
 
 import 'package:flutter/material.dart' hide TimeOfDay;
-import 'package:permission_handler/permission_handler.dart';
 import 'package:flutter/services.dart';
 
 import 'package:carp_serializable/carp_serializable.dart';

--- a/apps/carp_mobile_sensing_app/lib/main.dart
+++ b/apps/carp_mobile_sensing_app/lib/main.dart
@@ -1,8 +1,10 @@
 library mobile_sensing_app;
 
-import 'package:flutter/material.dart' hide TimeOfDay;
-import 'package:flutter/services.dart';
 import 'dart:async';
+
+import 'package:flutter/material.dart' hide TimeOfDay;
+import 'package:permission_handler/permission_handler.dart';
+import 'package:flutter/services.dart';
 
 import 'package:carp_serializable/carp_serializable.dart';
 import 'package:carp_core/carp_core.dart';

--- a/apps/carp_mobile_sensing_app/lib/src/app.dart
+++ b/apps/carp_mobile_sensing_app/lib/src/app.dart
@@ -37,7 +37,6 @@ class LoadingPage extends StatelessWidget {
     }
 
     await bloc.sensing.initialize();
-    // await bloc.requestPermission();
 
     return true;
   }

--- a/apps/carp_mobile_sensing_app/lib/src/app.dart
+++ b/apps/carp_mobile_sensing_app/lib/src/app.dart
@@ -95,7 +95,7 @@ class CarpMobileSensingAppState extends State<CarpMobileSensingApp> {
       ),
       floatingActionButton: FloatingActionButton(
         onPressed: _restart,
-        child: bloc.isRunning ? Icon(Icons.pause) : Icon(Icons.play_arrow),
+        child: bloc.isRunning ? Icon(Icons.stop) : Icon(Icons.play_arrow),
       ),
     );
   }

--- a/apps/carp_mobile_sensing_app/lib/src/app.dart
+++ b/apps/carp_mobile_sensing_app/lib/src/app.dart
@@ -1,4 +1,4 @@
-part of mobile_sensing_app;
+part of '../main.dart';
 
 class App extends StatelessWidget {
   @override
@@ -37,6 +37,8 @@ class LoadingPage extends StatelessWidget {
     }
 
     await bloc.sensing.initialize();
+    // await bloc.requestPermission();
+
     return true;
   }
 

--- a/apps/carp_mobile_sensing_app/lib/src/blocs/carp_backend.dart
+++ b/apps/carp_mobile_sensing_app/lib/src/blocs/carp_backend.dart
@@ -1,4 +1,4 @@
-part of mobile_sensing_app;
+part of '../../main.dart';
 
 /// Handling communication to the CARP Web Services infrastructure.
 ///

--- a/apps/carp_mobile_sensing_app/lib/src/blocs/local_study_protocol_manager.dart
+++ b/apps/carp_mobile_sensing_app/lib/src/blocs/local_study_protocol_manager.dart
@@ -84,36 +84,41 @@ class LocalStudyProtocolManager implements StudyProtocolManager {
     //     phone);
 
     // Define the online location service and add it as a 'device'
-    LocationService locationService = LocationService();
+    // final locationService = LocationService();
+
+    final locationService = LocationService(
+      // used for debugging when the phone is laying still on the table
+      distance: 0,
+    );
     protocol.addConnectedDevice(locationService, phone);
 
     // Add a background task that collects location on a regular basis
     protocol.addTaskControl(
-        PeriodicTrigger(period: Duration(seconds: 30)),
+        PeriodicTrigger(period: Duration(seconds: 20)),
         BackgroundTask(measures: [
           Measure(type: ContextSamplingPackage.CURRENT_LOCATION),
         ]),
         locationService);
 
-    // // Add a background task that continuously collects location and mobility
-    // protocol.addTaskControl(
-    //     ImmediateTrigger(),
-    //     BackgroundTask(measures: [
-    //       Measure(type: ContextSamplingPackage.LOCATION),
-    //       Measure(type: ContextSamplingPackage.MOBILITY),
-    //     ]),
-    //     locationService);
+    // Add a background task that continuously collects location and mobility
+    protocol.addTaskControl(
+        ImmediateTrigger(),
+        BackgroundTask(measures: [
+          Measure(type: ContextSamplingPackage.LOCATION),
+          Measure(type: ContextSamplingPackage.MOBILITY),
+        ]),
+        locationService);
 
-    // // Define the online weather service and add it as a 'device'
-    // WeatherService weatherService = WeatherService(apiKey: openWeatherApiKey);
-    // protocol.addConnectedDevice(weatherService, phone);
+    // Define the online weather service and add it as a 'device'
+    WeatherService weatherService = WeatherService(apiKey: openWeatherApiKey);
+    protocol.addConnectedDevice(weatherService, phone);
 
-    // // Add a background task that collects weather every 30 minutes.
-    // protocol.addTaskControl(
-    //     PeriodicTrigger(period: Duration(minutes: 30)),
-    //     BackgroundTask()
-    //       ..addMeasure(Measure(type: ContextSamplingPackage.WEATHER)),
-    //     weatherService);
+    // Add a background task that collects weather every 30 minutes.
+    protocol.addTaskControl(
+        PeriodicTrigger(period: Duration(seconds: 30)),
+        BackgroundTask()
+          ..addMeasure(Measure(type: ContextSamplingPackage.WEATHER)),
+        weatherService);
 
     // // Define the online air quality service and add it as a 'device'
     // AirQualityService airQualityService =

--- a/apps/carp_mobile_sensing_app/lib/src/blocs/local_study_protocol_manager.dart
+++ b/apps/carp_mobile_sensing_app/lib/src/blocs/local_study_protocol_manager.dart
@@ -1,11 +1,4 @@
-/*
- * Copyright 2019-2024 Copenhagen Center for Health Technology (CACHET) at the
- * Technical University of Denmark (DTU).
- * Use of this source code is governed by a MIT-style license that can be
- * found in the LICENSE file.
- */
-
-part of mobile_sensing_app;
+part of '../../main.dart';
 
 /// This is a local [StudyProtocolManager] which provides a [SmartphoneStudyProtocol]
 /// when running in local mode.
@@ -70,25 +63,25 @@ class LocalStudyProtocolManager implements StudyProtocolManager {
         ]),
         phone);
 
-    // a random trigger - 3-8 times during time period of 8-20
-    protocol.addTaskControl(
-        RandomRecurrentTrigger(
-          startTime: TimeOfDay(hour: 8),
-          endTime: TimeOfDay(hour: 20),
-          minNumberOfTriggers: 3,
-          maxNumberOfTriggers: 8,
-        ),
-        BackgroundTask(measures: [
-          Measure(type: DeviceSamplingPackage.DEVICE_INFORMATION)
-        ]),
-        phone);
+    // // a random trigger - 3-8 times during time period of 8-20
+    // protocol.addTaskControl(
+    //     RandomRecurrentTrigger(
+    //       startTime: TimeOfDay(hour: 8),
+    //       endTime: TimeOfDay(hour: 20),
+    //       minNumberOfTriggers: 3,
+    //       maxNumberOfTriggers: 8,
+    //     ),
+    //     BackgroundTask(measures: [
+    //       Measure(type: DeviceSamplingPackage.DEVICE_INFORMATION)
+    //     ]),
+    //     phone);
 
-    // activity measure using the phone
-    protocol.addTaskControl(
-        ImmediateTrigger(),
-        BackgroundTask(
-            measures: [Measure(type: ContextSamplingPackage.ACTIVITY)]),
-        phone);
+    // // activity measure using the phone
+    // protocol.addTaskControl(
+    //     ImmediateTrigger(),
+    //     BackgroundTask(
+    //         measures: [Measure(type: ContextSamplingPackage.ACTIVITY)]),
+    //     phone);
 
     // Define the online location service and add it as a 'device'
     LocationService locationService = LocationService();
@@ -96,57 +89,57 @@ class LocalStudyProtocolManager implements StudyProtocolManager {
 
     // Add a background task that collects location on a regular basis
     protocol.addTaskControl(
-        PeriodicTrigger(period: Duration(minutes: 5)),
+        PeriodicTrigger(period: Duration(seconds: 30)),
         BackgroundTask(measures: [
           Measure(type: ContextSamplingPackage.CURRENT_LOCATION),
         ]),
         locationService);
 
-    // Add a background task that continuously collects location and mobility
-    protocol.addTaskControl(
-        ImmediateTrigger(),
-        BackgroundTask(measures: [
-          Measure(type: ContextSamplingPackage.LOCATION),
-          Measure(type: ContextSamplingPackage.MOBILITY),
-        ]),
-        locationService);
+    // // Add a background task that continuously collects location and mobility
+    // protocol.addTaskControl(
+    //     ImmediateTrigger(),
+    //     BackgroundTask(measures: [
+    //       Measure(type: ContextSamplingPackage.LOCATION),
+    //       Measure(type: ContextSamplingPackage.MOBILITY),
+    //     ]),
+    //     locationService);
 
-    // Define the online weather service and add it as a 'device'
-    WeatherService weatherService = WeatherService(apiKey: openWeatherApiKey);
-    protocol.addConnectedDevice(weatherService, phone);
+    // // Define the online weather service and add it as a 'device'
+    // WeatherService weatherService = WeatherService(apiKey: openWeatherApiKey);
+    // protocol.addConnectedDevice(weatherService, phone);
 
-    // Add a background task that collects weather every 30 minutes.
-    protocol.addTaskControl(
-        PeriodicTrigger(period: Duration(minutes: 30)),
-        BackgroundTask()
-          ..addMeasure(Measure(type: ContextSamplingPackage.WEATHER)),
-        weatherService);
+    // // Add a background task that collects weather every 30 minutes.
+    // protocol.addTaskControl(
+    //     PeriodicTrigger(period: Duration(minutes: 30)),
+    //     BackgroundTask()
+    //       ..addMeasure(Measure(type: ContextSamplingPackage.WEATHER)),
+    //     weatherService);
 
-    // Define the online air quality service and add it as a 'device'
-    AirQualityService airQualityService =
-        AirQualityService(apiKey: airQualityApiKey);
-    protocol.addConnectedDevice(airQualityService, phone);
+    // // Define the online air quality service and add it as a 'device'
+    // AirQualityService airQualityService =
+    //     AirQualityService(apiKey: airQualityApiKey);
+    // protocol.addConnectedDevice(airQualityService, phone);
 
-    // Add a background task that air quality every 30 minutes.
-    protocol.addTaskControl(
-        PeriodicTrigger(period: Duration(minutes: 30)),
-        BackgroundTask()
-          ..addMeasure(Measure(type: ContextSamplingPackage.AIR_QUALITY)),
-        airQualityService);
+    // // Add a background task that air quality every 30 minutes.
+    // protocol.addTaskControl(
+    //     PeriodicTrigger(period: Duration(minutes: 30)),
+    //     BackgroundTask()
+    //       ..addMeasure(Measure(type: ContextSamplingPackage.AIR_QUALITY)),
+    //     airQualityService);
 
-    protocol.addTaskControl(
-        ImmediateTrigger(),
-        BackgroundTask()..addMeasure(Measure(type: MediaSamplingPackage.NOISE)),
-        phone);
+    // protocol.addTaskControl(
+    //     ImmediateTrigger(),
+    //     BackgroundTask()..addMeasure(Measure(type: MediaSamplingPackage.NOISE)),
+    //     phone);
 
-    protocol.addTaskControl(
-        ImmediateTrigger(),
-        BackgroundTask(measures: [
-          Measure(type: ConnectivitySamplingPackage.CONNECTIVITY),
-          Measure(type: ConnectivitySamplingPackage.WIFI),
-          Measure(type: ConnectivitySamplingPackage.BLUETOOTH),
-        ]),
-        phone);
+    // protocol.addTaskControl(
+    //     ImmediateTrigger(),
+    //     BackgroundTask(measures: [
+    //       Measure(type: ConnectivitySamplingPackage.CONNECTIVITY),
+    //       Measure(type: ConnectivitySamplingPackage.WIFI),
+    //       Measure(type: ConnectivitySamplingPackage.BLUETOOTH),
+    //     ]),
+    //     phone);
 
     // // Add an automatic task that collects SMS messages in/out
     // protocol.addTaskControl(
@@ -230,24 +223,24 @@ class LocalStudyProtocolManager implements StudyProtocolManager {
     //     ]),
     //     polar);
 
-    // Known Movensense devices:
-    //  - Movesense MD : 220330000122 : 0C:8C:DC:3F:B2:CD
-    //  - Movesense    : 233830000687 : 0C:8C:DC:1B:23:3E
-    var movesense = MovesenseDevice(
-      address: '0C:8C:DC:3F:B2:CD',
-      name: 'Movesense MD 2203300 00122',
-    );
+    // // Known Movensense devices:
+    // //  - Movesense MD : 220330000122 : 0C:8C:DC:3F:B2:CD
+    // //  - Movesense    : 233830000687 : 0C:8C:DC:1B:23:3E
+    // var movesense = MovesenseDevice(
+    //   address: '0C:8C:DC:3F:B2:CD',
+    //   name: 'Movesense MD 2203300 00122',
+    // );
 
-    protocol.addConnectedDevice(movesense, phone);
+    // protocol.addConnectedDevice(movesense, phone);
 
-    protocol.addTaskControl(
-        ImmediateTrigger(),
-        BackgroundTask(measures: [
-          Measure(type: MovesenseSamplingPackage.STATE),
-          Measure(type: MovesenseSamplingPackage.HR),
-          Measure(type: MovesenseSamplingPackage.ECG),
-        ]),
-        movesense);
+    // protocol.addTaskControl(
+    //     ImmediateTrigger(),
+    //     BackgroundTask(measures: [
+    //       Measure(type: MovesenseSamplingPackage.STATE),
+    //       Measure(type: MovesenseSamplingPackage.HR),
+    //       Measure(type: MovesenseSamplingPackage.ECG),
+    //     ]),
+    //     movesense);
 
     // // add a measure for ECG monitoring using the Movisens device
     // protocol.addTaskControl(

--- a/apps/carp_mobile_sensing_app/lib/src/blocs/sensing.dart
+++ b/apps/carp_mobile_sensing_app/lib/src/blocs/sensing.dart
@@ -1,11 +1,4 @@
-/*
- * Copyright 2021-2024 Copenhagen Center for Health Technology (CACHET) at the
- * Technical University of Denmark (DTU).
- * Use of this source code is governed by a MIT-style license that can be
- * found in the LICENSE file.
- */
-
-part of mobile_sensing_app;
+part of '../../main.dart';
 
 /// This class implements the sensing layer.
 ///
@@ -50,6 +43,10 @@ class Sensing {
   /// The study running on this phone.
   Study? study;
 
+  /// The deployment running on this phone.
+  /// Only available after [addStudy] is called.
+  SmartphoneDeployment? get deployment => controller?.deployment;
+
   /// Get the latest status of the study deployment.
   StudyDeploymentStatus? get status => _status;
 
@@ -76,6 +73,17 @@ class Sensing {
   /// The list of connected devices.
   List<DeviceManager> get connectedDevices =>
       SmartPhoneClientManager().deviceController.connectedDevices.toList();
+
+  /// The list of devices in the current deployment.
+  List<DeviceManager>? get deployedDevices => deployment != null
+      ? SmartPhoneClientManager()
+          .deviceController
+          .devices
+          .values
+          .where((manager) => deployment!.devices
+              .any((registration) => registration.type == manager.type))
+          .toList()
+      : [];
 
   /// Initialize and set up sensing.
   Future<void> initialize() async {

--- a/apps/carp_mobile_sensing_app/lib/src/blocs/sensing_bloc.dart
+++ b/apps/carp_mobile_sensing_app/lib/src/blocs/sensing_bloc.dart
@@ -1,4 +1,4 @@
-part of mobile_sensing_app;
+part of '../../main.dart';
 
 /// This is the main Business Logic Component (BLoC) of this sensing app.
 class SensingBLoC {
@@ -105,6 +105,10 @@ class SensingBLoC {
   Iterable<DeviceViewModel> get connectedDevices =>
       bloc.sensing.connectedDevices.map((device) => DeviceViewModel(device));
 
+  /// The list of all devices in this deployment.
+  Iterable<DeviceViewModel> get deployedDevices =>
+      bloc.sensing.deployedDevices!.map((device) => DeviceViewModel(device));
+
   /// Initialize the BLoC.
   Future<void> initialize({
     DeploymentMode deploymentMode = DeploymentMode.local,
@@ -129,6 +133,13 @@ class SensingBLoC {
       .deviceController
       .devices[device.type!]!
       .connect();
+
+  /// Request permissions to access location.
+  ///
+  /// If the result is [PermissionStatus.permanentlyDenied], no dialog will be
+  /// shown on [requestPermission].
+  Future<PermissionStatus> requestPermission() async =>
+      await Permission.locationAlways.request();
 
   void start() {
     SmartPhoneClientManager().notificationController?.createNotification(

--- a/apps/carp_mobile_sensing_app/lib/src/blocs/sensing_bloc.dart
+++ b/apps/carp_mobile_sensing_app/lib/src/blocs/sensing_bloc.dart
@@ -134,13 +134,6 @@ class SensingBLoC {
       .devices[device.type!]!
       .connect();
 
-  /// Request permissions to access location.
-  ///
-  /// If the result is [PermissionStatus.permanentlyDenied], no dialog will be
-  /// shown on [requestPermission].
-  Future<PermissionStatus> requestPermission() async =>
-      await Permission.locationAlways.request();
-
   void start() {
     SmartPhoneClientManager().notificationController?.createNotification(
           title: 'Sensing Started',

--- a/apps/carp_mobile_sensing_app/lib/src/view_models/device_view_model.dart
+++ b/apps/carp_mobile_sensing_app/lib/src/view_models/device_view_model.dart
@@ -1,4 +1,4 @@
-part of mobile_sensing_app;
+part of '../../main.dart';
 
 /// A view model for a [DeviceManager].
 class DeviceViewModel {

--- a/apps/carp_mobile_sensing_app/lib/src/view_models/probe_descriptions.dart
+++ b/apps/carp_mobile_sensing_app/lib/src/view_models/probe_descriptions.dart
@@ -9,7 +9,7 @@ class ProbeDescription {
   static Map<String, ProbeDescriptor> get descriptors => {
         DeviceSamplingPackage.FREE_MEMORY: ProbeDescriptor(
           'Memory',
-          'Collecting free physical and virtual memory.',
+          'Free physical and virtual memory.',
         ),
         DeviceSamplingPackage.DEVICE_INFORMATION: ProbeDescriptor(
           'Device',
@@ -17,19 +17,19 @@ class ProbeDescription {
         ),
         DeviceSamplingPackage.BATTERY_STATE: ProbeDescriptor(
           'Battery',
-          'Collecting battery level and charging status.',
+          'Battery level and charging status.',
         ),
         SensorSamplingPackage.STEP_COUNT: ProbeDescriptor(
           'Pedometer',
-          'Collecting step counts on a regular basis.',
+          'Step count events as steps are detected by the phone.',
         ),
         SensorSamplingPackage.ACCELERATION: ProbeDescriptor(
           'Accelerometer',
-          "Collecting sensor data from the phone's onboard accelerometer.",
+          "Sensor data from the phone's onboard accelerometer.",
         ),
         SensorSamplingPackage.ROTATION: ProbeDescriptor(
           'Gyroscope',
-          "Collecting sensor data from the phone's onboard gyroscope.",
+          "Sensor data from the phone's onboard gyroscope.",
         ),
         SensorSamplingPackage.AMBIENT_LIGHT: ProbeDescriptor(
           'Light',
@@ -37,27 +37,27 @@ class ProbeDescription {
         ),
         ConnectivitySamplingPackage.BLUETOOTH: ProbeDescriptor(
           'Bluetooth',
-          'Collecting nearby bluetooth devices on a regular basis.',
+          'Scans for nearby bluetooth devices on a regular basis.',
         ),
         ConnectivitySamplingPackage.WIFI: ProbeDescriptor(
           'Wifi',
-          'Collecting names of connected wifi networks (SSID and BSSID)',
+          'Collects names of connected wifi networks (SSID and BSSID)',
         ),
         ConnectivitySamplingPackage.CONNECTIVITY: ProbeDescriptor(
           'Connectivity',
-          'Collecting information on connectivity status and mode.',
+          'Information on connectivity status and mode.',
         ),
         MediaSamplingPackage.AUDIO: ProbeDescriptor(
           'Audio',
-          'Records ambient sound on a regular basis.',
+          'Ambient sound in the proximity of the phone.',
         ),
         MediaSamplingPackage.NOISE: ProbeDescriptor(
           'Noise',
-          'Measures noise level in decibel on a regular basis.',
+          "Ambient noise level in decibel as detected by the phone's microphone.",
         ),
         AppsSamplingPackage.APPS: ProbeDescriptor(
           'Apps',
-          'Collecting a list of installed apps.',
+          'Collects a list of installed apps.',
         ),
         AppsSamplingPackage.APP_USAGE: ProbeDescriptor(
           'App Usage',
@@ -81,31 +81,31 @@ class ProbeDescription {
         // ),
         DeviceSamplingPackage.SCREEN_EVENT: ProbeDescriptor(
           'Screen',
-          'Collecting screen events (on/off/unlock).',
+          'Screen events (on/off/unlock).',
         ),
         ContextSamplingPackage.CURRENT_LOCATION: ProbeDescriptor(
           'Current Location',
-          'Collecting location information.',
+          "Current location colleted from the phone's GPS sensor.",
         ),
         ContextSamplingPackage.LOCATION: ProbeDescriptor(
           'Location Tracking',
-          'Collecting location information.',
+          "Continuous location tracking from the phone's GPS sensor.",
         ),
         ContextSamplingPackage.ACTIVITY: ProbeDescriptor(
           'Activity',
-          'Recognize physical activity, e.g. sitting, walking, biking.',
+          'Physical activity as detected by the phone, e.g., sitting, walking, biking.',
         ),
         ContextSamplingPackage.WEATHER: ProbeDescriptor(
           'Weather',
-          'Collects local weather.',
+          'Collects local weather information.',
         ),
         ContextSamplingPackage.AIR_QUALITY: ProbeDescriptor(
           'Air Quality',
-          'Collects local air quality.',
+          'Collects local air quality information.',
         ),
         ContextSamplingPackage.GEOFENCE: ProbeDescriptor(
           'Geofence',
-          'Track movement in/out of this geofence.',
+          'Track movement in/out of a geographical ares (geofence).',
         ),
         ContextSamplingPackage.MOBILITY: ProbeDescriptor(
           'Mobility',

--- a/apps/carp_mobile_sensing_app/lib/src/view_models/probe_descriptions.dart
+++ b/apps/carp_mobile_sensing_app/lib/src/view_models/probe_descriptions.dart
@@ -1,4 +1,4 @@
-part of mobile_sensing_app;
+part of '../../main.dart';
 
 class ProbeDescriptor {
   String name, description;

--- a/apps/carp_mobile_sensing_app/lib/src/view_models/probe_view_model.dart
+++ b/apps/carp_mobile_sensing_app/lib/src/view_models/probe_view_model.dart
@@ -1,4 +1,4 @@
-part of mobile_sensing_app;
+part of '../../main.dart';
 
 /// A view model for a [Probe].
 class ProbeViewModel {

--- a/apps/carp_mobile_sensing_app/lib/src/view_models/study_deployment_view_model.dart
+++ b/apps/carp_mobile_sensing_app/lib/src/view_models/study_deployment_view_model.dart
@@ -1,4 +1,4 @@
-part of mobile_sensing_app;
+part of '../../main.dart';
 
 /// A view model for the [StudyDeploymentPage] view.
 class StudyDeploymentViewModel {

--- a/apps/carp_mobile_sensing_app/lib/src/view_models/study_deployment_view_model.dart
+++ b/apps/carp_mobile_sensing_app/lib/src/view_models/study_deployment_view_model.dart
@@ -17,7 +17,7 @@ class StudyDeploymentViewModel {
   Stream<ExecutorState> get studyExecutorStateEvents =>
       bloc.sensing.controller!.executor.stateEvents;
 
-  /// Current state of the study executor (e.g., resumed, paused, ...)
+  /// Current state of the study executor (e.g., started, stopped, ...)
   ExecutorState get studyState => bloc.sensing.controller!.executor.state;
 
   /// Get all sensing events (i.e. all [Measurement] objects being collected).

--- a/apps/carp_mobile_sensing_app/lib/src/views/cachet_colors.dart
+++ b/apps/carp_mobile_sensing_app/lib/src/views/cachet_colors.dart
@@ -1,4 +1,4 @@
-part of mobile_sensing_app;
+part of '../../main.dart';
 
 /// An implementation of the default CACHET colors.
 class CachetColors {

--- a/apps/carp_mobile_sensing_app/lib/src/views/device_list_page.dart
+++ b/apps/carp_mobile_sensing_app/lib/src/views/device_list_page.dart
@@ -1,4 +1,4 @@
-part of mobile_sensing_app;
+part of '../../main.dart';
 
 class DevicesListPage extends StatefulWidget {
   @override
@@ -11,7 +11,7 @@ class DevicesListPageState extends State<DevicesListPage> {
 
   @override
   Widget build(BuildContext context) {
-    List<DeviceViewModel> devices = bloc.connectedDevices.toList();
+    List<DeviceViewModel> devices = bloc.deployedDevices.toList();
 
     return Scaffold(
       key: scaffoldKey,
@@ -47,10 +47,10 @@ class DevicesListPageState extends State<DevicesListPage> {
                 subtitle: Text(device.description),
                 trailing: device.stateIcon,
               ),
-              const Divider(),
-              TextButton(
-                  child: const Text('How to use this device?'),
-                  onPressed: () => print('Use the $device')),
+              // const Divider(),
+              // TextButton(
+              //     child: const Text('How to use this device?'),
+              //     onPressed: () => print('Use the $device')),
               FutureBuilder<bool>(
                   future: device.deviceManager.hasPermissions(),
                   builder: (

--- a/apps/carp_mobile_sensing_app/lib/src/views/probe_list_page.dart
+++ b/apps/carp_mobile_sensing_app/lib/src/views/probe_list_page.dart
@@ -1,4 +1,4 @@
-part of mobile_sensing_app;
+part of '../../main.dart';
 
 class ProbesListPage extends StatefulWidget {
   @override

--- a/apps/carp_mobile_sensing_app/lib/src/views/study_deployment_page.dart
+++ b/apps/carp_mobile_sensing_app/lib/src/views/study_deployment_page.dart
@@ -1,4 +1,4 @@
-part of mobile_sensing_app;
+part of '../../main.dart';
 
 class StudyDeploymentPage extends StatefulWidget {
   @override

--- a/apps/carp_mobile_sensing_app/pubspec.yaml
+++ b/apps/carp_mobile_sensing_app/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_launcher_icons: ^0.13.0
+  permission_handler: ^11.0.1
   
   carp_serializable: ^1.1.0
   #carp_core: ^0.30.0

--- a/apps/carp_mobile_sensing_app/pubspec.yaml
+++ b/apps/carp_mobile_sensing_app/pubspec.yaml
@@ -12,7 +12,6 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_launcher_icons: ^0.13.0
-  permission_handler: ^11.0.1
   
   carp_serializable: ^1.1.0
   #carp_core: ^0.30.0

--- a/apps/carp_mobile_sensing_app/test/CAMS_app_test.dart
+++ b/apps/carp_mobile_sensing_app/test/CAMS_app_test.dart
@@ -51,8 +51,9 @@ void main() {
     // generate the protocol to be used in testing below
     // setting the right accountId, if to be uploaded to CAWS
     protocol ??= LocalStudyProtocolManager()
-        .getSingleUserStudyProtocol('CAMS Health Protocol');
-    // .getFamilyStudyProtocol('CAMS Demo App Protocol - Family study with Participant Data');
+        // .getSingleUserStudyProtocol('CAMS Health Protocol');
+        .getFamilyStudyProtocol(
+            'CAMS Demo App Protocol - Family study with Participant Data');
 
     protocol?.ownerId = accountId;
   });

--- a/carp_mobile_sensing/CHANGELOG.md
+++ b/carp_mobile_sensing/CHANGELOG.md
@@ -1,7 +1,8 @@
-## 1.8.0
+## 1.8.1
 
 - Added support for extension of triggers, [#403](https://github.com/cph-cachet/carp.sensing-flutter/issues/403). See the section on [Adding new Trigger](https://github.com/cph-cachet/carp.sensing-flutter/wiki/5.-Extending-CARP-Mobile-Sensing#adding-new-triggers) on the CAMS wiki.
 - Refactor of the software architecture to align better with a domain-driven design architecture.
+- Improvements to executor state machine (can only restart an executor/probe that is already started)
 
 ## 1.7.1
 

--- a/carp_mobile_sensing/lib/runtime/device_manager.dart
+++ b/carp_mobile_sensing/lib/runtime/device_manager.dart
@@ -202,7 +202,6 @@ abstract class DeviceManager<TDeviceConfiguration extends DeviceConfiguration>
     info('$runtimeType - Restarting sampling...');
 
     for (var executor in executors) {
-      debug('$runtimeType - Restarting $executor');
       executor.restart();
     }
   }
@@ -231,9 +230,8 @@ abstract class DeviceManager<TDeviceConfiguration extends DeviceConfiguration>
       info(
           '$runtimeType - Trying to disconnect from device of type: $typeName and id: $id');
 
-      // Stop all sampling and heartbeat monitoring on this device.
+      // Stop all sampling on this device.
       stop();
-      stopHeartbeatMonitoring();
 
       success = await onDisconnect();
       status = (success) ? DeviceStatus.disconnected : DeviceStatus.error;

--- a/carp_mobile_sensing/lib/runtime/executors/executors.dart
+++ b/carp_mobile_sensing/lib/runtime/executors/executors.dart
@@ -397,21 +397,6 @@ class _InitializedState extends _AbstractExecutorState
       executor._isStarting = false;
     });
   }
-
-  // @override
-  // void restart() {
-  //   executor.onRestart().then((restarted) {
-  //     if (restarted) executor.start();
-  //   });
-  // }
-
-  // @override
-  // void stop() {
-  //   executor.onStop().then((stopped) {
-  //     if (stopped) executor._setState(_StoppedState(executor));
-  //     debug('$executor - stopped');
-  //   });
-  // }
 }
 
 class _StartedState extends _AbstractExecutorState {

--- a/carp_mobile_sensing/pubspec.yaml
+++ b/carp_mobile_sensing/pubspec.yaml
@@ -1,6 +1,6 @@
 name: carp_mobile_sensing
 description: Mobile Sensing Framework for Flutter. A software framework for collecting sensor data from the phone and attached wearable devices via probes. Can be extended.
-version: 1.8.0
+version: 1.8.1
 homepage: https://github.com/cph-cachet/carp.sensing-flutter
 
 environment:

--- a/packages/carp_context_package/CHANGELOG.md
+++ b/packages/carp_context_package/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.7.0
+
+* putting the location plugin back in businees (instead of the geolocator plugin)
+* revisiting issue [#389](https://github.com/cph-cachet/carp.sensing-flutter/issues/389), making a new implementation of the getCurrentLocation() method
+* improved the README to better explain how to handle location permissions on iOS
+
 ## 1.6.0
 
 * replacing the location plugin with the geolocator plugin

--- a/packages/carp_context_package/README.md
+++ b/packages/carp_context_package/README.md
@@ -23,7 +23,7 @@ See the [CARP Mobile Sensing App](https://github.com/cph-cachet/carp.sensing-flu
 For Flutter plugins for other CARP products, see [CARP Mobile Sensing in Flutter](https://github.com/cph-cachet/carp.sensing-flutter).
 
 If you're interested in writing you own sampling packages for CARP, see the description on
-how to [extend](https://github.com/cph-cachet/carp.sensing-flutter/wiki/5.-Extending-CARP-Mobile-Sensing) CARP on the wiki.
+how to [extend](https://github.com/cph-cachet/carp.sensing-flutter/wiki/5.-Extending-CARP-Mobile-Sensing) CARP Mobile Sensing on the wiki.
 
 ## Installing
 
@@ -153,7 +153,9 @@ Before creating a study and running it, register this package in the [SamplingPa
 SamplingPackageRegistry().register(ContextSamplingPackage());
 ````
 
-The context package uses different "services" to collect data.
+The context package uses different "services" (incl. the phone itself) to collect data.
+
+### Activity Measure
 
 The `ACTIVITY` measure uses the phone itself and can be added like this:
 
@@ -177,6 +179,8 @@ protocol.addTaskControl(
     phone);
 ```
 
+### Location Measures
+
 All of the location-based measures;
 
 * `LOCATION`
@@ -184,7 +188,7 @@ All of the location-based measures;
 * `GEOFENCE`
 * `MOBILITY`
 
-uses the `LocationService` service as a "connected device" to collect data and can be added to a protocol like this:
+use the `LocationService` service as a "connected device" to collect data and can be added to a protocol like this:
 
 ```dart
 // Define the online location service and add it as a 'connected device'
@@ -206,8 +210,10 @@ protocol.addTaskControl(
 
 > Note that you would often need to balance the configuration of the `LocationService` with the measure you are collecting. For example, if only using the `MOBILITY` measure, a lower `accuracy`, `distance`, and sampling `interval` could be used.
 
+### Weather and Air Quality Measures
+
 The `WEATHER` and `AIR_QUALITY` measures uses the online [Open Weather API](https://openweathermap.org/api) and [Air Quality Open Data Platform](https://aqicn.org/data-platform/token/#/), respectively.
-In order to use these service, you need to obtain an API key from each of them.
+In order to use these services, you need to obtain an API key from each of them.
 Once you have this, these services can be configured and added to a protocol like this:
 
 ```dart

--- a/packages/carp_context_package/lib/carp_context_package.dart
+++ b/packages/carp_context_package/lib/carp_context_package.dart
@@ -15,10 +15,10 @@ import 'package:openmhealth_schemas/openmhealth_schemas.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:air_quality/air_quality.dart' as waqi;
 import 'package:mobility_features/mobility_features.dart';
-// import 'package:location/location.dart' as location;
-import 'package:geolocator/geolocator.dart' as geolocator;
-import 'package:geolocator_apple/geolocator_apple.dart';
-import 'package:geolocator_android/geolocator_android.dart';
+import 'package:location/location.dart' as location;
+// import 'package:geolocator/geolocator.dart' as geolocator;
+// import 'package:geolocator_apple/geolocator_apple.dart';
+// import 'package:geolocator_android/geolocator_android.dart';
 // import 'package:carp_background_location/carp_background_location.dart' as cbl;
 // import 'package:activity_recognition_flutter/activity_recognition_flutter.dart';
 import 'package:flutter_activity_recognition/flutter_activity_recognition.dart'

--- a/packages/carp_context_package/lib/carp_context_package.dart
+++ b/packages/carp_context_package/lib/carp_context_package.dart
@@ -1,5 +1,6 @@
 /// A library for collecting context information on:
 ///  * location
+///  * geofence
 ///  * activity
 ///  * weather
 ///  * air quality
@@ -7,7 +8,6 @@
 library carp_context_package;
 
 import 'dart:async';
-import 'dart:io';
 import 'dart:math' as math;
 import 'package:json_annotation/json_annotation.dart';
 import 'package:weather/weather.dart' as weather;

--- a/packages/carp_context_package/lib/src/location/location_data.dart
+++ b/packages/carp_context_package/lib/src/location/location_data.dart
@@ -83,40 +83,40 @@ class Location extends Geolocation {
     this.provider,
   }) : super();
 
-  // /// Create a [Location] object based on a [LocationData] from the `location` plugin.
-  // Location.fromLocationData(location.LocationData location) : super() {
-  //   latitude = location.latitude ?? 0;
-  //   longitude = location.longitude ?? 0;
-  //   altitude = location.altitude;
-  //   accuracy = location.accuracy;
-  //   verticalAccuracy = location.verticalAccuracy;
-  //   speed = location.speed;
-  //   speedAccuracy = location.speedAccuracy;
-  //   heading = location.heading;
-  //   time = (location.time != null)
-  //       ? DateTime.fromMillisecondsSinceEpoch(location.time!.toInt())
-  //       : null;
-  //   isMock = location.isMock;
-  //   headingAccuracy = location.headingAccuracy;
-  //   elapsedRealtimeNanos = location.elapsedRealtimeNanos;
-  //   elapsedRealtimeUncertaintyNanos = location.elapsedRealtimeUncertaintyNanos;
-  //   satellites = location.satelliteNumber;
-  // }
-
-  /// Create a [Location] object based on a [Position] from the `geolocator` plugin.
-  Location.fromPositionData(geolocator.Position position) : super() {
-    latitude = position.latitude;
-    longitude = position.longitude;
-    altitude = position.altitude;
-    accuracy = position.accuracy;
-    verticalAccuracy = position.altitudeAccuracy;
-    speed = position.speed;
-    speedAccuracy = position.speedAccuracy;
-    heading = position.heading;
-    time = position.timestamp.toUtc();
-    isMock = position.isMocked;
-    headingAccuracy = position.headingAccuracy;
+  /// Create a [Location] object based on a [LocationData] from the `location` plugin.
+  Location.fromLocationData(location.LocationData location) : super() {
+    latitude = location.latitude ?? 0;
+    longitude = location.longitude ?? 0;
+    altitude = location.altitude;
+    accuracy = location.accuracy;
+    verticalAccuracy = location.verticalAccuracy;
+    speed = location.speed;
+    speedAccuracy = location.speedAccuracy;
+    heading = location.heading;
+    time = (location.time != null)
+        ? DateTime.fromMillisecondsSinceEpoch(location.time!.toInt())
+        : null;
+    isMock = location.isMock;
+    headingAccuracy = location.headingAccuracy;
+    elapsedRealtimeNanos = location.elapsedRealtimeNanos;
+    elapsedRealtimeUncertaintyNanos = location.elapsedRealtimeUncertaintyNanos;
+    satellites = location.satelliteNumber;
   }
+
+  // /// Create a [Location] object based on a [Position] from the `geolocator` plugin.
+  // Location.fromPositionData(geolocator.Position position) : super() {
+  //   latitude = position.latitude;
+  //   longitude = position.longitude;
+  //   altitude = position.altitude;
+  //   accuracy = position.accuracy;
+  //   verticalAccuracy = position.altitudeAccuracy;
+  //   speed = position.speed;
+  //   speedAccuracy = position.speedAccuracy;
+  //   heading = position.heading;
+  //   time = position.timestamp.toUtc();
+  //   isMock = position.isMocked;
+  //   headingAccuracy = position.headingAccuracy;
+  // }
 
   // /// Create a [Location] object based on a [LocationDto] from the
   // /// `carp_background_location` plugin.

--- a/packages/carp_context_package/lib/src/location/location_probes.dart
+++ b/packages/carp_context_package/lib/src/location/location_probes.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 Copenhagen Center for Health Technology (CACHET) at the
+ * Copyright 2018 Copenhagen Center for Health Technology (CACHET) at the
  * Technical University of Denmark (DTU).
  * Use of this source code is governed by a MIT-style license that can be
  * found in the LICENSE file.

--- a/packages/carp_context_package/lib/src/location_manager.dart
+++ b/packages/carp_context_package/lib/src/location_manager.dart
@@ -38,6 +38,190 @@ enum GeolocationAccuracy {
   reduced,
 }
 
+/// A manger that knows how to get location information.
+/// Provide access to location data while the app is in the background.
+///
+/// Use as a singleton:
+///
+///  `LocationManager()...`
+///
+/// Note that this [LocationManager] **tries** to handle location permissions
+/// during its configuration (via the [configure] method) and the [hasPermission]
+/// and [requestPermission] methods.
+///
+/// **However**, it is much better - and also recommended by both Apple and
+/// Google - to handle permissions on an application level and show the location
+/// permission dialogue to the user **before** using probes that depend on location.
+///
+/// This [LocationManager] based on the [location](https://pub.dev/packages/location)
+/// plugin.
+class LocationManager {
+  static final LocationManager _instance = LocationManager._();
+  LocationManager._();
+
+  /// Get the singleton [LocationManager] instance
+  factory LocationManager() => _instance;
+
+  bool _enabled = false, _configured = false;
+  final _provider = location.Location();
+  Location? _lastKnownLocation;
+
+  /// Is the location service enabled, which entails that
+  ///  * location service is enabled
+  ///  * permissions granted
+  bool get enabled => _enabled;
+
+  /// Is the location service configured via the [configure] method.
+  bool get configured => _configured;
+
+  /// Is the location service enabled in background mode?
+  Future<bool> isBackgroundModeEnabled() async =>
+      await _provider.isBackgroundModeEnabled();
+
+  /// Does this location manger have permission to access location "always"?
+  ///
+  /// If the result is [PermissionStatus.permanentlyDenied], no dialog will be
+  /// shown on [requestPermission].
+  Future<PermissionStatus> hasPermission() async =>
+      await Permission.locationAlways.status;
+
+  /// Has location been granted to this location manager?
+  Future<bool> isGranted() async =>
+      (await hasPermission()) == PermissionStatus.granted;
+
+  /// Request permissions to access location.
+  ///
+  /// If the result is [PermissionStatus.permanentlyDenied], no dialog will be
+  /// shown on [requestPermission].
+  Future<PermissionStatus> requestPermission() async {
+    var serviceEnabled =
+        await Permission.locationWhenInUse.serviceStatus.isEnabled;
+
+    // return await Permission.locationAlways.request();
+    var permission = await Permission.location.request();
+
+    debug('$runtimeType'
+        ' - Location service enabled: $serviceEnabled'
+        ' - permission: $permission');
+
+    // if (await Permission.location.isPermanentlyDenied) {
+    if (permission == PermissionStatus.permanentlyDenied) {
+      // The user opted to never again see the permission request dialog for this
+      // app. The only way to change the permission's status now is to let the
+      // user manually enables it in the system settings.
+      debug('$runtimeType - trying to open app settings.');
+      openAppSettings();
+    }
+
+    return permission;
+  }
+
+  /// Enable the [LocationManager], incl. sending a notification to the
+  /// Android notification system.
+  ///
+  /// After the location manager is enabled, configuration can be done via the
+  /// [configure] method.
+  Future<void> enable() async {
+    // fast out if already enabled
+    if (enabled) return;
+
+    info('Enabling $runtimeType...');
+    _enabled = false;
+
+    bool serviceEnabled = await _provider.serviceEnabled();
+    if (!serviceEnabled) {
+      serviceEnabled = await _provider.requestService();
+      if (!serviceEnabled) {
+        warning('$runtimeType - Location service could not be enabled.');
+        return;
+      }
+    }
+
+    var permission = await _provider.hasPermission();
+
+    if (permission != location.PermissionStatus.granted) {
+      warning(
+          "$runtimeType - Permission to collect location data 'Always' in the background has not been granted. "
+          "Make sure to grant this BEFORE sensing is resumed. "
+          "The context sampling package does not handle permissions. This should be handled on the application level.");
+    }
+
+    _enabled = true;
+
+    bool backgroundMode = false;
+    try {
+      backgroundMode = await _provider.enableBackgroundMode();
+    } catch (error) {
+      warning('$runtimeType - Could not enable background mode - $error');
+    }
+
+    info('$runtimeType'
+        ' - service enabled: $serviceEnabled'
+        ' - permission: $permission'
+        ' - background mode: $backgroundMode');
+  }
+
+  /// Configures the [LocationManager], incl. sending a notification to the
+  /// Android notification system.
+  ///
+  /// Configuration is done based on the [LocationService]. If not provided,
+  /// as set of default configurations are used.
+  Future<void> configure(LocationService configuration) async {
+    // fast out if already configured
+    if (configured) return;
+
+    // ensured that this location manager is enable first
+    await enable();
+
+    info('Configuring $runtimeType - configuration: $configuration');
+    _configured = false;
+
+    try {
+      await _provider.changeSettings(
+        accuracy:
+            location.LocationAccuracy.values[configuration.accuracy.index],
+        distanceFilter: configuration.distance,
+        interval: configuration.interval.inMilliseconds,
+      );
+
+      await _provider.changeNotificationOptions(
+          title: configuration.notificationTitle ?? 'CARP Location Service',
+          subtitle: configuration.notificationMessage ??
+              'The location service is running in the background',
+          description: configuration.notificationDescription ??
+              'Background location is on to keep the CARP Mobile Sensing app up-to-date with your location. '
+                  'This is required for main features to work properly when the app is not in use.',
+          onTapBringToFront: configuration.notificationOnTapBringToFront,
+          iconName: configuration.notificationIconName);
+
+      info('$runtimeType - configured successfully.');
+      _configured = true;
+    } catch (error) {
+      warning('$runtimeType - Configuration failed - $error');
+      return;
+    }
+  }
+
+  /// The last know location, if any.
+  Location? get lastKnownLocation => _lastKnownLocation;
+
+  /// Gets the current location of the phone.
+  ///
+  /// Throws an error if location cannot be obtained within a few seconds or
+  /// if the app has no permission to access location.
+  Future<Location> getLocation() async => _lastKnownLocation =
+      Location.fromLocationData(await _provider.getLocation().timeout(
+            const Duration(seconds: 6),
+            // onTimeout: () => lastKnownLocation,
+          ));
+
+  /// Returns a stream of [Location] objects.
+  ///
+  /// Throws an error if the app has no permission to access location.
+  Stream<Location> get onLocationChanged => _provider.onLocationChanged.map(
+      (location) => _lastKnownLocation = Location.fromLocationData(location));
+}
+
 // /// A manger that knows how to get location information.
 // /// Provide access to location data while the app is in the background.
 // ///
@@ -53,7 +237,7 @@ enum GeolocationAccuracy {
 // /// Google - to handle permissions on an application level and show the location
 // /// permission dialogue to the user **before** using probes that depend on location.
 // ///
-// /// This [LocationManager] based on the [location](https://pub.dev/packages/location)
+// /// This [LocationManager] based on the [geolocator](https://pub.dev/packages/geolocator)
 // /// plugin.
 // class LocationManager {
 //   static final LocationManager _instance = LocationManager._();
@@ -63,8 +247,8 @@ enum GeolocationAccuracy {
 //   factory LocationManager() => _instance;
 
 //   bool _enabled = false, _configured = false;
-//   final _provider = location.Location();
 //   Location? _lastKnownLocation;
+//   geolocator.LocationSettings? _settings;
 
 //   /// Is the location service enabled, which entails that
 //   ///  * location service is enabled
@@ -74,9 +258,9 @@ enum GeolocationAccuracy {
 //   /// Is the location service configured via the [configure] method.
 //   bool get configured => _configured;
 
-//   /// Is the location service enabled in background mode?
-//   Future<bool> isBackgroundModeEnabled() async =>
-//       await _provider.isBackgroundModeEnabled();
+//   // /// Is the location service enabled in background mode?
+//   // Future<bool> isBackgroundModeEnabled() async =>
+//   //     await _provider.isBackgroundModeEnabled();
 
 //   /// Does this location manger have permission to access location "always"?
 //   ///
@@ -108,16 +292,15 @@ enum GeolocationAccuracy {
 //     info('Enabling $runtimeType...');
 //     _enabled = false;
 
-//     bool serviceEnabled = await _provider.serviceEnabled();
+//     bool serviceEnabled =
+//         await geolocator.Geolocator.isLocationServiceEnabled();
 //     if (!serviceEnabled) {
-//       serviceEnabled = await _provider.requestService();
-//       if (!serviceEnabled) {
-//         warning('$runtimeType - Location service could not be enabled.');
-//         return;
-//       }
+//       warning('$runtimeType - Location service is not enabled on this device.');
+//       return;
 //     }
 
-//     if (await _provider.hasPermission() != location.PermissionStatus.granted) {
+//     if (await geolocator.Geolocator.checkPermission() !=
+//         geolocator.LocationPermission.always) {
 //       warning(
 //           "$runtimeType - Permission to collect location data 'Always' in the background has not been granted. "
 //           "Make sure to grant this BEFORE sensing is resumed. "
@@ -125,14 +308,7 @@ enum GeolocationAccuracy {
 //     }
 
 //     _enabled = true;
-
-//     bool backgroundMode = false;
-//     try {
-//       backgroundMode = await _provider.enableBackgroundMode();
-//     } catch (error) {
-//       warning('$runtimeType - Could not enable background mode - $error');
-//     }
-//     info('$runtimeType - enabled, background mode: $backgroundMode');
+//     info('$runtimeType - enabled.');
 //   }
 
 //   /// Configures the [LocationManager], incl. sending a notification to the
@@ -150,225 +326,75 @@ enum GeolocationAccuracy {
 //     info('Configuring $runtimeType - configuration: $configuration');
 //     _configured = false;
 
-//     try {
-//       await _provider.changeSettings(
+//     if (Platform.isAndroid) {
+//       _settings = AndroidSettings(
+//           accuracy:
+//               geolocator.LocationAccuracy.values[configuration.accuracy.index],
+//           distanceFilter: configuration.distance.toInt(),
+//           forceLocationManager: true,
+//           intervalDuration: configuration.interval,
+//           // Set foreground notification config to keep the app alive when going to the background
+//           foregroundNotificationConfig: const ForegroundNotificationConfig(
+//             notificationText:
+//                 'Background location is on to keep the CARP Mobile Sensing app up-to-date with your location. '
+//                 'This is required for main features to work properly when the app is not in use.',
+//             notificationTitle: "CARP Location Service",
+//             enableWakeLock: true,
+//           ));
+//     } else if (Platform.isAndroid) {
+//       _settings = AppleSettings(
 //         accuracy:
-//             location.LocationAccuracy.values[configuration.accuracy.index],
-//         distanceFilter: configuration.distance,
-//         interval: configuration.interval.inMilliseconds,
+//             geolocator.LocationAccuracy.values[configuration.accuracy.index],
+//         distanceFilter: configuration.distance.toInt(),
+//         timeLimit: configuration.interval,
+//         // activityType: geolocator.ActivityType.fitness,
+//         pauseLocationUpdatesAutomatically: true,
+//         allowBackgroundLocationUpdates: true,
+//         // Only set to true if our app will be started up in the background.
+//         showBackgroundLocationIndicator: false,
 //       );
-
-//       await _provider.changeNotificationOptions(
-//           title: configuration.notificationTitle ?? 'CARP Location Service',
-//           subtitle: configuration.notificationMessage ??
-//               'The location service is running in the background',
-//           description: configuration.notificationDescription ??
-//               'Background location is on to keep the CARP Mobile Sensing app up-to-date with your location. '
-//                   'This is required for main features to work properly when the app is not in use.',
-//           onTapBringToFront: configuration.notificationOnTapBringToFront,
-//           iconName: configuration.notificationIconName);
-
-//       info('$runtimeType - configured successfully.');
-//       _configured = true;
-//     } catch (error) {
-//       warning('$runtimeType - Configuration failed - $error');
-//       return;
+//     } else {
+//       _settings = LocationSettings(
+//         accuracy:
+//             geolocator.LocationAccuracy.values[configuration.accuracy.index],
+//         distanceFilter: configuration.distance.toInt(),
+//         timeLimit: configuration.interval,
+//       );
 //     }
+
+//     info('$runtimeType - configured successfully.');
+//     _configured = true;
 //   }
 
-//   /// The last know location, if any.
-//   Location? get lastKnownLocation => _lastKnownLocation;
+//   /// Gets the last known location of the phone.
+//   ///
+//   /// Throws an error if location cannot be obtained within a few seconds or
+//   /// if the app has no permission to access location.
+//   Future<Location?> lastKnownLocation() async {
+//     var position = await geolocator.Geolocator.getLastKnownPosition()
+//         .timeout(const Duration(seconds: 10));
+
+//     return position != null
+//         ? _lastKnownLocation = Location.fromPositionData(position)
+//         : _lastKnownLocation;
+//   }
 
 //   /// Gets the current location of the phone.
 //   ///
 //   /// Throws an error if location cannot be obtained within a few seconds or
 //   /// if the app has no permission to access location.
-//   Future<Location> getLocation() async => _lastKnownLocation =
-//       Location.fromLocationData(await _provider.getLocation().timeout(
-//             const Duration(seconds: 6),
-//             // onTimeout: () => lastKnownLocation,
-//           ));
+//   Future<Location> getLocation() async =>
+//       _lastKnownLocation = Location.fromPositionData(
+//           await geolocator.Geolocator.getCurrentPosition().timeout(
+//         const Duration(seconds: 10),
+//       ));
 
 //   /// Returns a stream of [Location] objects.
 //   ///
 //   /// Throws an error if the app has no permission to access location.
-//   Stream<Location> get onLocationChanged => _provider.onLocationChanged.map(
-//       (location) => _lastKnownLocation = Location.fromLocationData(location));
+//   Stream<Location> get onLocationChanged =>
+//       geolocator.Geolocator.getPositionStream(
+//         locationSettings: _settings,
+//       ).map((position) =>
+//           _lastKnownLocation = Location.fromPositionData(position));
 // }
-
-/// A manger that knows how to get location information.
-/// Provide access to location data while the app is in the background.
-///
-/// Use as a singleton:
-///
-///  `LocationManager()...`
-///
-/// Note that this [LocationManager] **tries** to handle location permissions
-/// during its configuration (via the [configure] method) and the [hasPermission]
-/// and [requestPermission] methods.
-///
-/// **However**, it is much better - and also recommended by both Apple and
-/// Google - to handle permissions on an application level and show the location
-/// permission dialogue to the user **before** using probes that depend on location.
-///
-/// This [LocationManager] based on the [geolocator](https://pub.dev/packages/geolocator)
-/// plugin.
-class LocationManager {
-  static final LocationManager _instance = LocationManager._();
-  LocationManager._();
-
-  /// Get the singleton [LocationManager] instance
-  factory LocationManager() => _instance;
-
-  bool _enabled = false, _configured = false;
-  Location? _lastKnownLocation;
-  geolocator.LocationSettings? _settings;
-
-  /// Is the location service enabled, which entails that
-  ///  * location service is enabled
-  ///  * permissions granted
-  bool get enabled => _enabled;
-
-  /// Is the location service configured via the [configure] method.
-  bool get configured => _configured;
-
-  // /// Is the location service enabled in background mode?
-  // Future<bool> isBackgroundModeEnabled() async =>
-  //     await _provider.isBackgroundModeEnabled();
-
-  /// Does this location manger have permission to access location "always"?
-  ///
-  /// If the result is [PermissionStatus.permanentlyDenied], no dialog will be
-  /// shown on [requestPermission].
-  Future<PermissionStatus> hasPermission() async =>
-      await Permission.locationAlways.status;
-
-  /// Has location been granted to this location manager?
-  Future<bool> isGranted() async =>
-      (await hasPermission()) == PermissionStatus.granted;
-
-  /// Request permissions to access location.
-  ///
-  /// If the result is [PermissionStatus.permanentlyDenied], no dialog will be
-  /// shown on [requestPermission].
-  Future<PermissionStatus> requestPermission() async =>
-      await Permission.locationAlways.request();
-
-  /// Enable the [LocationManager], incl. sending a notification to the
-  /// Android notification system.
-  ///
-  /// After the location manager is enabled, configuration can be done via the
-  /// [configure] method.
-  Future<void> enable() async {
-    // fast out if already enabled
-    if (enabled) return;
-
-    info('Enabling $runtimeType...');
-    _enabled = false;
-
-    bool serviceEnabled =
-        await geolocator.Geolocator.isLocationServiceEnabled();
-    if (!serviceEnabled) {
-      warning('$runtimeType - Location service is not enabled on this device.');
-      return;
-    }
-
-    if (await geolocator.Geolocator.checkPermission() !=
-        geolocator.LocationPermission.always) {
-      warning(
-          "$runtimeType - Permission to collect location data 'Always' in the background has not been granted. "
-          "Make sure to grant this BEFORE sensing is resumed. "
-          "The context sampling package does not handle permissions. This should be handled on the application level.");
-    }
-
-    _enabled = true;
-    info('$runtimeType - enabled.');
-  }
-
-  /// Configures the [LocationManager], incl. sending a notification to the
-  /// Android notification system.
-  ///
-  /// Configuration is done based on the [LocationService]. If not provided,
-  /// as set of default configurations are used.
-  Future<void> configure(LocationService configuration) async {
-    // fast out if already configured
-    if (configured) return;
-
-    // ensured that this location manager is enable first
-    await enable();
-
-    info('Configuring $runtimeType - configuration: $configuration');
-    _configured = false;
-
-    if (Platform.isAndroid) {
-      _settings = AndroidSettings(
-          accuracy:
-              geolocator.LocationAccuracy.values[configuration.accuracy.index],
-          distanceFilter: configuration.distance.toInt(),
-          forceLocationManager: true,
-          intervalDuration: configuration.interval,
-          // Set foreground notification config to keep the app alive when going to the background
-          foregroundNotificationConfig: const ForegroundNotificationConfig(
-            notificationText:
-                'Background location is on to keep the CARP Mobile Sensing app up-to-date with your location. '
-                'This is required for main features to work properly when the app is not in use.',
-            notificationTitle: "CARP Location Service",
-            enableWakeLock: true,
-          ));
-    } else if (Platform.isAndroid) {
-      _settings = AppleSettings(
-        accuracy:
-            geolocator.LocationAccuracy.values[configuration.accuracy.index],
-        distanceFilter: configuration.distance.toInt(),
-        timeLimit: configuration.interval,
-        // activityType: geolocator.ActivityType.fitness,
-        pauseLocationUpdatesAutomatically: true,
-        allowBackgroundLocationUpdates: true,
-        // Only set to true if our app will be started up in the background.
-        showBackgroundLocationIndicator: false,
-      );
-    } else {
-      _settings = LocationSettings(
-        accuracy:
-            geolocator.LocationAccuracy.values[configuration.accuracy.index],
-        distanceFilter: configuration.distance.toInt(),
-        timeLimit: configuration.interval,
-      );
-    }
-
-    info('$runtimeType - configured successfully.');
-    _configured = true;
-  }
-
-  /// Gets the last known location of the phone.
-  ///
-  /// Throws an error if location cannot be obtained within a few seconds or
-  /// if the app has no permission to access location.
-  Future<Location?> lastKnownLocation() async {
-    var position = await geolocator.Geolocator.getLastKnownPosition()
-        .timeout(const Duration(seconds: 10));
-
-    return position != null
-        ? _lastKnownLocation = Location.fromPositionData(position)
-        : _lastKnownLocation;
-  }
-
-  /// Gets the current location of the phone.
-  ///
-  /// Throws an error if location cannot be obtained within a few seconds or
-  /// if the app has no permission to access location.
-  Future<Location> getLocation() async =>
-      _lastKnownLocation = Location.fromPositionData(
-          await geolocator.Geolocator.getCurrentPosition().timeout(
-        const Duration(seconds: 10),
-      ));
-
-  /// Returns a stream of [Location] objects.
-  ///
-  /// Throws an error if the app has no permission to access location.
-  Stream<Location> get onLocationChanged =>
-      geolocator.Geolocator.getPositionStream(
-        locationSettings: _settings,
-      ).map((position) =>
-          _lastKnownLocation = Location.fromPositionData(position));
-}

--- a/packages/carp_context_package/lib/src/location_manager.dart
+++ b/packages/carp_context_package/lib/src/location_manager.dart
@@ -237,12 +237,20 @@ class LocationManager {
   /// Gets the current location of the phone.
   ///
   /// Throws an error if location cannot be obtained within a few seconds or
-  /// if the app has no permission to access location.
+  /// if the app does not have permission to access location.
   Future<Location> getLocation() async => _lastKnownLocation =
-      Location.fromLocationData(await _provider.getLocation().timeout(
-            const Duration(seconds: 6),
-            // onTimeout: () => lastKnownLocation,
-          ));
+      await onLocationChanged.first.timeout(const Duration(seconds: 6));
+
+  // The following implementation of getLocation() does not work, since the
+  // _provider.getLocation() method sometimes never returns.
+  //
+  // See issue https://github.com/cph-cachet/carp.sensing-flutter/issues/389
+  //
+  // Future<Location> getLocation() async => _lastKnownLocation =
+  //     Location.fromLocationData(await _provider.getLocation().timeout(
+  //           const Duration(seconds: 6),
+  //           // onTimeout: () => lastKnownLocation,
+  //         ));
 
   /// Returns a stream of [Location] objects.
   ///

--- a/packages/carp_context_package/pubspec.yaml
+++ b/packages/carp_context_package/pubspec.yaml
@@ -22,10 +22,10 @@ dependencies:
   flutter_activity_recognition: ^3.0.0
   openmhealth_schemas: ^0.3.0
   mobility_features: ^4.0.0
-  # location: ^6.0.0
-  geolocator: ^11.0.0
-  geolocator_apple: ^2.3.0
-  geolocator_android: ^4.5.0
+  location: ^6.0.0
+  # geolocator: ^11.0.0
+  # geolocator_apple: ^2.3.0
+  # geolocator_android: ^4.5.0
   # carp_background_location: ^4.0.0 # the CARP location plugin
 
 # Overriding carp libraries to use the local copy

--- a/packages/carp_context_package/pubspec.yaml
+++ b/packages/carp_context_package/pubspec.yaml
@@ -1,6 +1,6 @@
 name: carp_context_package
 description: CARP context sampling package. Samples location, mobility, activity, weather, air-quality, and geofence.
-version: 1.6.0
+version: 1.7.0
 homepage: https://github.com/cph-cachet/carp.sensing-flutter/tree/master/packages/carp_context_package
 
 environment:


### PR DESCRIPTION
# carp_mobile_sensing

## 1.8.1

- Added support for extension of triggers, [#403](https://github.com/cph-cachet/carp.sensing-flutter/issues/403). See the section on [Adding new Trigger](https://github.com/cph-cachet/carp.sensing-flutter/wiki/5.-Extending-CARP-Mobile-Sensing#adding-new-triggers) on the CAMS wiki.
- Refactor of the software architecture to align better with a domain-driven design architecture.
- Improvements to executor state machine (can only restart an executor/probe that is already started)

# carp_context_package

## 1.7.0

* putting the location plugin back in businees (instead of the geolocator plugin)
* revisiting issue [#389](https://github.com/cph-cachet/carp.sensing-flutter/issues/389), making a new implementation of the getCurrentLocation() method
* improved the README to better explain how to handle location permissions on iOS
