### PR TITLE
carp_mobile_sensing 1.11.3

### DIFF
--- a/backends/carp_backend/test/carp_backend_test.dart
+++ b/backends/carp_backend/test/carp_backend_test.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'package:carp_serializable/carp_serializable.dart';
 import 'package:flutter/material.dart';
 import 'package:test/test.dart';
 // import 'package:flutter_test/flutter_test.dart';
@@ -257,19 +258,17 @@ void main() {
 
   group("Documents & Collections", () {
     test('- get by id', () async {
-      DocumentSnapshot? doc = await CarpService().documentById(167).get();
-      print(doc);
+      final doc = await CarpService().documentById(102).get();
+      print(toJsonString(doc?.data));
     });
 
     test('- get by collection', () async {
-      CollectionReference ref =
-          await CarpService().collection('localizations').get();
+      final ref = await CarpService().collection('localizations').get();
       print((ref));
     });
 
     test(' - get document by path', () async {
-      DocumentSnapshot? doc =
-          await CarpService().document('localizations/da').get();
+      final doc = await CarpService().document('localizations/da').get();
       print((doc));
     });
 

--- a/backends/carp_backend/test/json/messages.json
+++ b/backends/carp_backend/test/json/messages.json
@@ -1,0 +1,50 @@
+      {
+        "id": 30,
+        "name": "messages",
+        "study_id": "d6d047d5-4cfd-479b-87ac-99f4b5fee172",
+        "study_deployment_id": "",
+        "document_id": null,
+        "documents": [
+          {
+            "id": 103,
+            "name": "ebc95008-76f9-4a08-8805-7f580bdbbee1",
+            "collection_id": 30,
+            "data": {
+              "id": "8f63d8e8-6001-4f9b-9d70-9731a25d3a92",
+              "url": "https://github.com/cph-cachet/carp.sensing-flutter/issues/434",
+              "type": "news",
+              "image": null,
+              "title": "Test news",
+              "message": "Jakob testing",
+              "subTitle": "For unit testing",
+              "timestamp": "2024-10-28T20:27:03.561Z"
+            },
+            "created_by": "9c354cd9-0fd9-49a4-910d-46b28ea43997",
+            "created_at": "2024-10-28T20:27:03.781416Z",
+            "updated_by": "9c354cd9-0fd9-49a4-910d-46b28ea43997",
+            "updated_at": "2024-10-28T20:27:03.781416Z"
+          },
+          {
+            "id": 102,
+            "name": "8d67565c-9f21-449f-bf8a-b084e15b771e",
+            "collection_id": 30,
+            "data": {
+              "id": "8d67565c-9f21-449f-bf8a-b084e15b771e",
+              "url": "https://www.who.int/initiatives/behealthy/healthy-diet",
+              "type": "article",
+              "title": "The importance of healthy eating",
+              "message": "A healthy diet is essential for good health and nutrition. It protects you against many chronic noncommunicable diseases, such as heart disease, diabetes and cancer. Eating a variety of foods and consuming less salt, sugars and saturated and industrially-produced trans-fats, are essential for healthy diet.\n\nA healthy diet comprises a combination of different foods. These include:\n\n - Staples like cereals (wheat, barley, rye, maize or rice) or starchy tubers or roots (potato, yam, taro or cassava).\n - Legumes (lentils and beans).\n - Fruit and vegetables.\n - Foods from animal sources (meat, fish, eggs and milk).\n\nHere is some useful information, based on WHO recommendations, to follow a healthy diet, and the benefits of doing so.",
+              "sub_title": "",
+              "timestamp": "2024-10-28T21:18:11.275882"
+            },
+            "created_by": "9c354cd9-0fd9-49a4-910d-46b28ea43997",
+            "created_at": "2024-10-28T20:18:11.719098Z",
+            "updated_by": "9c354cd9-0fd9-49a4-910d-46b28ea43997",
+            "updated_at": "2024-10-28T20:18:11.719098Z"
+          }
+        ],
+        "created_by": "9c354cd9-0fd9-49a4-910d-46b28ea43997",
+        "created_at": "2024-09-25T11:33:43.252362Z",
+        "updated_by": "9c354cd9-0fd9-49a4-910d-46b28ea43997",
+        "updated_at": "2024-09-25T11:33:43.252362Z"
+      }

--- a/carp_mobile_sensing/CHANGELOG.md
+++ b/carp_mobile_sensing/CHANGELOG.md
@@ -1,8 +1,9 @@
-## 1.11.2
+## 1.11.3
 
 * Extended the `SmartphoneStudy` and `SmartphoneDeployment` to hold info on participant ID and participant role for a study running on the phone. This helps upload participant data (like informed consent) without the need to specify this every time.
 * Fix of [#429](https://github.com/cph-cachet/carp.sensing-flutter/issues/429)
 * Fix of [#430](https://github.com/cph-cachet/carp.sensing-flutter/issues/430)
+* Fix of [#431](https://github.com/cph-cachet/carp_studies_app/issues/341)
 
 ## 1.10.0
 

--- a/carp_mobile_sensing/lib/runtime/app_task_controller.dart
+++ b/carp_mobile_sensing/lib/runtime/app_task_controller.dart
@@ -161,7 +161,6 @@ class AppTaskController {
     DateTime? triggerTime,
     bool sendNotification = true,
   }) {
-    debug('$runtimeType - Buffering task $executor for later scheduling.');
     _userTaskBuffer.add(UserTaskBufferItem(
       taskControl,
       executor,

--- a/carp_mobile_sensing/lib/runtime/executors/task_control_executors.dart
+++ b/carp_mobile_sensing/lib/runtime/executors/task_control_executors.dart
@@ -126,7 +126,7 @@ class TaskControlExecutor extends AbstractExecutor<TaskControl> {
 ///
 /// In contrast to the [TaskControlExecutor] (which runs in the background),
 /// this [AppTaskControlExecutor] will try to schedule the [AppTask] using
-/// the [AppTaskController]. This means that the [trigger] for has to be
+/// the [AppTaskController]. This means that the [trigger] has to be
 /// [Schedulable].
 class AppTaskControlExecutor extends TaskControlExecutor {
   AppTaskControlExecutor(

--- a/carp_mobile_sensing/pubspec.yaml
+++ b/carp_mobile_sensing/pubspec.yaml
@@ -1,6 +1,6 @@
 name: carp_mobile_sensing
 description: Mobile Sensing Framework for Flutter. A software framework for collecting sensor data from the phone and attached wearable devices via probes. Can be extended.
-version: 1.11.2
+version: 1.11.3
 homepage: https://github.com/cph-cachet/carp.sensing-flutter
 
 environment:

--- a/packages/carp_audio_package/CHANGELOG.md
+++ b/packages/carp_audio_package/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 1.7.0
+## 1.7.1
 
-* upgrade to carp_serialization v. 2.0 & carp_mobile_sensing: 1.10.0
+* upgrade to carp_serialization v. 2.0 & carp_mobile_sensing: 1.11.0
+* Fix of [#431](https://github.com/cph-cachet/carp_studies_app/issues/341)
 
 ## 1.6.0
 

--- a/packages/carp_audio_package/lib/audio_probe.dart
+++ b/packages/carp_audio_package/lib/audio_probe.dart
@@ -57,8 +57,6 @@ class AudioProbe extends Probe {
         debug(' $runtimeType [$hashCode] - Audio recording stopped.');
 
         // when stopping the audio sampling, stop recording and collect the measurement
-        // HOWEVER - this does not work....?
-        // issue => https://github.com/cph-cachet/carp_studies_app/issues/341
         if (_data != null) {
           _data?.endRecordingTime = DateTime.now().toUtc();
           var measurement = Measurement(

--- a/packages/carp_audio_package/pubspec.yaml
+++ b/packages/carp_audio_package/pubspec.yaml
@@ -1,6 +1,6 @@
 name: carp_audio_package
 description: CARP Media Sampling Package. Samples audio, video, image, and noise.
-version: 1.7.0
+version: 1.7.1
 homepage: https://github.com/cph-cachet/carp.sensing-flutter/tree/master/packages/carp_audio_package
 
 environment:
@@ -13,7 +13,7 @@ dependencies:
     
   carp_serializable: ^2.0.0
   carp_core: ^1.8.0
-  carp_mobile_sensing: ^1.10.0
+  carp_mobile_sensing: ^1.11.0
  
   json_annotation: ^4.8.0
   permission_handler: ^11.0.0  


### PR DESCRIPTION
## 1.11.3

* Extended the `SmartphoneStudy` and `SmartphoneDeployment` to hold info on participant ID and participant role for a study running on the phone. This helps upload participant data (like informed consent) without the need to specify this every time.
* Fix of [#429](https://github.com/cph-cachet/carp.sensing-flutter/issues/429)
* Fix of [#430](https://github.com/cph-cachet/carp.sensing-flutter/issues/430)
* Fix of [#431](https://github.com/cph-cachet/carp_studies_app/issues/341)