### PR TITLE
Refix of #488

### DIFF
--- a/carp_mobile_sensing/CHANGELOG.md
+++ b/carp_mobile_sensing/CHANGELOG.md
@@ -1,6 +1,6 @@
-## 1.12.5
+## 1.12.6
 
-* getting rid of `ONE_TIME_SENSING_TYPE` - not there is only one type of sensing user task ( [#488](https://github.com/cph-cachet/carp.sensing-flutter/issues/488))
+* deprecating the `ONE_TIME_SENSING_TYPE` - not there is only one type of sensing user task ( [#488](https://github.com/cph-cachet/carp.sensing-flutter/issues/488))
 
 ## 1.12.4
 

--- a/carp_mobile_sensing/lib/runtime/executors/deployment_executor.dart
+++ b/carp_mobile_sensing/lib/runtime/executors/deployment_executor.dart
@@ -59,13 +59,18 @@ class SmartphoneDeploymentExecutor
     AppTaskController()
         .userTaskEvents
         .where((userTask) => userTask.state == UserTaskState.done)
-        .listen((userTask) {
-      addMeasurement(Measurement.fromData(CompletedAppTask(
-        taskName: userTask.name,
-        taskType: userTask.type,
-        taskData: userTask.result,
-      )));
-    });
+        .listen(
+            (userTask) => addMeasurement(Measurement.fromData(CompletedAppTask(
+                  taskName: userTask.name,
+                  taskType:
+                      // this is a temporary workaround to support the old one_time_sensing task type
+                      // see issue #488
+                      userTask.type ==
+                              BackgroundSensingUserTask.ONE_TIME_SENSING_TYPE
+                          ? BackgroundSensingUserTask.SENSING_TYPE
+                          : userTask.type,
+                  taskData: userTask.result,
+                ))));
 
     return true;
   }

--- a/carp_mobile_sensing/lib/runtime/user_tasks.dart
+++ b/carp_mobile_sensing/lib/runtime/user_tasks.dart
@@ -21,6 +21,7 @@ class SensingUserTaskFactory implements UserTaskFactory {
   @override
   List<String> types = [
     BackgroundSensingUserTask.SENSING_TYPE,
+    BackgroundSensingUserTask.ONE_TIME_SENSING_TYPE,
   ];
 
   @override
@@ -232,8 +233,13 @@ enum UserTaskState {
 /// It starts when the [onStart] methods is called and stops when the
 /// [onDone] methods is called.
 class BackgroundSensingUserTask extends UserTask {
-  /// A type of sensing user task which can be started and stopped.
+  /// A background sensing user task which can be started and stopped.
   static const String SENSING_TYPE = 'sensing';
+
+  /// A background sensing user task which runs once and then stops.
+  @Deprecated('Use BackgroundSensingUserTask.SENSING_TYPE instead. '
+      'This will be removed in a future version.')
+  static const String ONE_TIME_SENSING_TYPE = 'one_time_sensing';
 
   BackgroundSensingUserTask(super.executor);
 

--- a/carp_mobile_sensing/pubspec.yaml
+++ b/carp_mobile_sensing/pubspec.yaml
@@ -1,6 +1,6 @@
 name: carp_mobile_sensing
 description: Mobile Sensing Framework for Flutter. A software framework for collecting sensor data from the phone and attached wearable devices via probes. Can be extended.
-version: 1.12.5
+version: 1.12.6
 homepage: https://github.com/cph-cachet/carp.sensing-flutter
 
 environment:


### PR DESCRIPTION
#488 refix - making "one_time_sensing" deprecated instead of removing it totally. Make protocol backward compatible.. 