### PR TITLE
Bluetooth scan filters (to enable background scanning on Android)

### DIFF
--- a/carp_mobile_sensing/lib/domain.g.dart
+++ b/carp_mobile_sensing/lib/domain.g.dart
@@ -284,6 +284,38 @@ Map<String, dynamic> _$PeriodicSamplingConfigurationToJson(
       'duration': instance.duration.inMicroseconds,
     };
 
+BluetoothScanPeriodicSamplingConfiguration
+    _$BluetoothScanPeriodicSamplingConfigurationFromJson(
+            Map<String, dynamic> json) =>
+        BluetoothScanPeriodicSamplingConfiguration(
+          interval: Duration(microseconds: (json['interval'] as num).toInt()),
+          duration: Duration(microseconds: (json['duration'] as num).toInt()),
+          withServices: (json['withServices'] as List<dynamic>?)
+                  ?.map((e) => e as String)
+                  .toList() ??
+              [],
+          withRemoteIds: (json['withRemoteIds'] as List<dynamic>?)
+                  ?.map((e) => e as String)
+                  .toList() ??
+              [],
+        )
+          ..$type = json['__type'] as String?
+          ..lastTime = json['lastTime'] == null
+              ? null
+              : DateTime.parse(json['lastTime'] as String);
+
+Map<String, dynamic> _$BluetoothScanPeriodicSamplingConfigurationToJson(
+        BluetoothScanPeriodicSamplingConfiguration instance) =>
+    <String, dynamic>{
+      if (instance.$type case final value?) '__type': value,
+      if (instance.lastTime?.toIso8601String() case final value?)
+        'lastTime': value,
+      'interval': instance.interval.inMicroseconds,
+      'duration': instance.duration.inMicroseconds,
+      'withServices': instance.withServices,
+      'withRemoteIds': instance.withRemoteIds,
+    };
+
 OnlineService<TRegistration> _$OnlineServiceFromJson<
         TRegistration extends DeviceRegistration>(Map<String, dynamic> json) =>
     OnlineService<TRegistration>(

--- a/carp_mobile_sensing/lib/domain/sampling_configurations.dart
+++ b/carp_mobile_sensing/lib/domain/sampling_configurations.dart
@@ -89,39 +89,3 @@ class PeriodicSamplingConfiguration extends IntervalSamplingConfiguration {
   factory PeriodicSamplingConfiguration.fromJson(Map<String, dynamic> json) =>
       FromJsonFactory().fromJson<PeriodicSamplingConfiguration>(json);
 }
-
-/// A sampling configuration specifying how to collect data on a regular basis
-/// for a specific period, specifically for Bluetooth scanning.
-///
-/// Data collection will be started as specified by the [interval] for a time
-/// period specified as the [duration]. Added for bluetooth scanning is filtering
-/// on the [withServices] and [withRemoteIds] to only collect data from
-/// specific services and remote ids.
-///
-/// Filtering on remoteIds allows Android to scan for devices in the background
-/// without needing to be in the foreground. This is not possible on iOS.
-@JsonSerializable(includeIfNull: false, explicitToJson: true)
-class BluetoothScanPeriodicSamplingConfiguration
-    extends PeriodicSamplingConfiguration {
-  /// The sampling duration.
-  List<String> withServices;
-  List<String> withRemoteIds;
-
-  BluetoothScanPeriodicSamplingConfiguration({
-    required super.interval,
-    required super.duration,
-    this.withServices = [],
-    this.withRemoteIds = [],
-  });
-
-  @override
-  Map<String, dynamic> toJson() =>
-      _$BluetoothScanPeriodicSamplingConfigurationToJson(this);
-  @override
-  Function get fromJsonFunction =>
-      _$BluetoothScanPeriodicSamplingConfigurationFromJson;
-  factory BluetoothScanPeriodicSamplingConfiguration.fromJson(
-          Map<String, dynamic> json) =>
-      FromJsonFactory()
-          .fromJson<BluetoothScanPeriodicSamplingConfiguration>(json);
-}

--- a/packages/carp_connectivity_package/lib/connectivity.g.dart
+++ b/packages/carp_connectivity_package/lib/connectivity.g.dart
@@ -83,3 +83,35 @@ Map<String, dynamic> _$WifiToJson(Wifi instance) => <String, dynamic>{
       if (instance.bssid case final value?) 'bssid': value,
       if (instance.ip case final value?) 'ip': value,
     };
+
+BluetoothScanPeriodicSamplingConfiguration
+    _$BluetoothScanPeriodicSamplingConfigurationFromJson(
+            Map<String, dynamic> json) =>
+        BluetoothScanPeriodicSamplingConfiguration(
+          interval: Duration(microseconds: (json['interval'] as num).toInt()),
+          duration: Duration(microseconds: (json['duration'] as num).toInt()),
+          withServices: (json['withServices'] as List<dynamic>?)
+                  ?.map((e) => e as String)
+                  .toList() ??
+              const [],
+          withRemoteIds: (json['withRemoteIds'] as List<dynamic>?)
+                  ?.map((e) => e as String)
+                  .toList() ??
+              const [],
+        )
+          ..$type = json['__type'] as String?
+          ..lastTime = json['lastTime'] == null
+              ? null
+              : DateTime.parse(json['lastTime'] as String);
+
+Map<String, dynamic> _$BluetoothScanPeriodicSamplingConfigurationToJson(
+        BluetoothScanPeriodicSamplingConfiguration instance) =>
+    <String, dynamic>{
+      if (instance.$type case final value?) '__type': value,
+      if (instance.lastTime?.toIso8601String() case final value?)
+        'lastTime': value,
+      'interval': instance.interval.inMicroseconds,
+      'duration': instance.duration.inMicroseconds,
+      'withServices': instance.withServices,
+      'withRemoteIds': instance.withRemoteIds,
+    };

--- a/packages/carp_connectivity_package/lib/connectivity_package.dart
+++ b/packages/carp_connectivity_package/lib/connectivity_package.dart
@@ -84,3 +84,41 @@ class ConnectivitySamplingPackage extends SmartphoneSamplingPackage {
         .add(WIFI, wifiNameAnonymizer);
   }
 }
+
+/// A sampling configuration specifying how to scan for Bluetooth devices on a
+/// regular basis for a specific period.
+///
+/// Data collection will be started as specified by the [interval] for a time
+/// period specified as the [duration]. Bluetooth scanning is filtering
+/// on the [withServices] and [withRemoteIds] to only collect data from
+/// specific services and remote ids.
+///
+/// Filtering on remoteIds allows Android to scan for devices in the background
+/// without needing to be in the foreground. This is not possible on iOS.
+@JsonSerializable(includeIfNull: false, explicitToJson: true)
+class BluetoothScanPeriodicSamplingConfiguration
+    extends PeriodicSamplingConfiguration {
+  /// List of Bluetooth service UUIDs to filter the scan results.
+  List<String> withServices;
+
+  /// List of remote device IDs to filter the scan results.
+  List<String> withRemoteIds;
+
+  BluetoothScanPeriodicSamplingConfiguration({
+    required super.interval,
+    required super.duration,
+    this.withServices = const [],
+    this.withRemoteIds = const [],
+  });
+
+  @override
+  Map<String, dynamic> toJson() =>
+      _$BluetoothScanPeriodicSamplingConfigurationToJson(this);
+  @override
+  Function get fromJsonFunction =>
+      _$BluetoothScanPeriodicSamplingConfigurationFromJson;
+  factory BluetoothScanPeriodicSamplingConfiguration.fromJson(
+          Map<String, dynamic> json) =>
+      FromJsonFactory()
+          .fromJson<BluetoothScanPeriodicSamplingConfiguration>(json);
+}

--- a/packages/carp_connectivity_package/lib/connectivity_probes.dart
+++ b/packages/carp_connectivity_package/lib/connectivity_probes.dart
@@ -56,8 +56,10 @@ class WifiProbe extends IntervalProbe {
 
 /// The [BluetoothProbe] scans for nearby and visible Bluetooth devices and
 /// collects a [Bluetooth] measurement that lists each device found during the scan.
+///
 /// Uses a [PeriodicSamplingConfiguration] for configuration the [interval]
-/// and [duration] of the scan.
+/// and [duration] of the scan. Can also be configured to filter by
+/// [services] and [remoteIds] by using a [BluetoothScanPeriodicSamplingConfiguration].
 class BluetoothProbe extends BufferingPeriodicStreamProbe {
   /// Default timeout for bluetooth scan - 4 secs
   static const DEFAULT_TIMEOUT = 4 * 1000;
@@ -70,25 +72,28 @@ class BluetoothProbe extends BufferingPeriodicStreamProbe {
   Future<Measurement?> getMeasurement() async =>
       _data != null ? Measurement.fromData(_data!) : null;
 
-  List<Guid> services = [];
-  List<String> remoteIds = [];
+  // if a BT-specific sampling configuration is used, we need to
+  // extract the services and remoteIds from it so FlutterBluePlus can
+  // perform filtered scanning
+
+  List<Guid> get services => (samplingConfiguration
+          is BluetoothScanPeriodicSamplingConfiguration)
+      ? (samplingConfiguration as BluetoothScanPeriodicSamplingConfiguration)
+          .withServices
+          .map((e) => Guid(e))
+          .toList()
+      : [];
+
+  List<String> get remoteIds => (samplingConfiguration
+          is BluetoothScanPeriodicSamplingConfiguration)
+      ? (samplingConfiguration as BluetoothScanPeriodicSamplingConfiguration)
+          .withRemoteIds
+      : [];
 
   @override
   void onSamplingStart() {
-    if (samplingConfiguration is BluetoothScanPeriodicSamplingConfiguration) {
-      // if a BT-specific sampling configuration is used, we need to
-      // extract the services and remoteIds from it so FlutterBluePlus can
-      // perform filtered scanning
-      List<Guid> services =
-          (samplingConfiguration as BluetoothScanPeriodicSamplingConfiguration)
-              .withServices
-              .map((e) => Guid(e))
-              .toList();
-      List<String> remoteIds =
-          (samplingConfiguration as BluetoothScanPeriodicSamplingConfiguration)
-              .withRemoteIds;
-    }
     _data = Bluetooth();
+
     try {
       FlutterBluePlus.startScan(
           withServices: services,


### PR DESCRIPTION
Added a `BluetoothScanPeriodicSamplingConfiguration` to be used with the `BluetoothProbe`. I have tested addition this by using it in our platform (m-Path) where this method has worked admirably.