### PR TITLE
fix(context): absorb native location stream errors in LocationManager

### DIFF
--- a/packages/carp_context_package/lib/src/location_manager.dart
+++ b/packages/carp_context_package/lib/src/location_manager.dart
@@ -282,10 +282,16 @@ class LocationManager {
 
   /// Returns a stream of [Location] objects.
   ///
-  /// Throws an error if the app has no permission to access location.
-  Stream<Location> get onLocationChanged => _provider.onLocationChanged.map(
-    (location) => _lastKnownLocation = Location.fromLocationData(location),
-  );
+  /// The underlying native `location` plugin reports permission errors
+  /// (e.g. PERMISSION_DENIED_NEVER_ASK) on its event channel. `handleError`
+  /// absorbs them here so they don't propagate as unhandled future errors
+  /// to downstream subscribers.
+  Stream<Location> get onLocationChanged =>
+      _provider.onLocationChanged.handleError((Object error) {
+        warning('$runtimeType - native location stream error absorbed: $error');
+      }).map(
+        (location) => _lastKnownLocation = Location.fromLocationData(location),
+      );
 
   @override
   toString() => configuration != null


### PR DESCRIPTION
## Summary
The native `location` plugin emits permission errors (e.g. `PERMISSION_DENIED_NEVER_ASK`) on its event channel. Without a handler they propagate as unhandled async errors to every subscriber of `LocationManager.onLocationChanged` — including `MobilityFeatures.startListening`, which subscribes without an `onError` callback and crashes the isolate.

Absorb them once at the source via `handleError` on `LocationManager.onLocationChanged`, logging a warning instead.

## Test plan
- [x] Run a study with location-dependent probes on a device where location permission is denied or revoked mid-run; confirm no unhandled `PlatformException` and a warning is logged.
- [ ] Verify normal location streaming still works when permission is granted.