### PR TITLE
fix: support upgrading apps from CAMS 1.x to 2.x

### DIFF
--- a/carp_mobile_sensing/lib/carp_mobile_sensing.json.dart
+++ b/carp_mobile_sensing/lib/carp_mobile_sensing.json.dart
@@ -27,6 +27,23 @@ void _registerFromJsonFunctions() {
     ServiceRegistration(),
   ]);
 
+  // Backwards compatibility with CAMS 1.x (protocol API level < 2.0) where
+  // device configurations and registrations used the carp_core device
+  // namespace. Maps old type names to the corresponding CAMS 2.x classes so
+  // that old protocols and deployments still can be deserialized.
+  FromJsonFactory().register(
+    Smartphone(),
+    type: '${DeviceConfiguration.DEVICE_NAMESPACE}.Smartphone',
+  );
+  FromJsonFactory().register(
+    BLEHeartRateDevice(roleName: ''),
+    type: '${DeviceConfiguration.DEVICE_NAMESPACE}.BLEHeartRateDevice',
+  );
+  FromJsonFactory().register(
+    SmartphoneRegistration(),
+    type: '${DeviceConfiguration.DEVICE_NAMESPACE}.SmartphoneDeviceRegistration',
+  );
+
   // Task classes
   FromJsonFactory().registerAll([
     AppTask(type: ''),

--- a/carp_mobile_sensing/lib/domain.g.dart
+++ b/carp_mobile_sensing/lib/domain.g.dart
@@ -632,10 +632,11 @@ SmartphoneDeployment _$SmartphoneDeploymentFromJson(
             const {},
       )
       ..applicationData = json['applicationData'] as Map<String, dynamic>?
-      ..deployed = DateTime.parse(json['deployed'] as String)
-      ..status = $enumDecode(
-        _$StudyDeploymentStatusTypesEnumMap,
-        json['status'],
+      ..deployed = SmartphoneDeployment._deployedFromJson(
+        json['deployed'] as String?,
+      )
+      ..status = SmartphoneDeployment._statusFromJson(
+        json['status'] as String?,
       );
 
 Map<String, dynamic> _$SmartphoneDeploymentToJson(

--- a/carp_mobile_sensing/lib/domain.g.dart
+++ b/carp_mobile_sensing/lib/domain.g.dart
@@ -318,9 +318,11 @@ BLEDevice<TRegistration> _$BLEDeviceFromJson<
     BLEDevice<TRegistration>(
         roleName: json['roleName'] as String,
         isOptional: json['isOptional'] as bool? ?? true,
-        serviceUuids: (json['serviceUuids'] as List<dynamic>?)
-            ?.map((e) => e as String)
-            .toList(),
+        serviceUuids:
+            (json['serviceUuids'] as List<dynamic>?)
+                ?.map((e) => e as String)
+                .toList() ??
+            [],
         namePrefix: json['namePrefix'] as String?,
         minRssi: (json['minRssi'] as num?)?.toInt(),
         allowDuplicates: json['allowDuplicates'] as bool? ?? true,
@@ -357,9 +359,11 @@ BLEHeartRateDevice _$BLEHeartRateDeviceFromJson(Map<String, dynamic> json) =>
     BLEHeartRateDevice(
         roleName: json['roleName'] as String,
         isOptional: json['isOptional'] as bool? ?? true,
-        serviceUuids: (json['serviceUuids'] as List<dynamic>?)
-            ?.map((e) => e as String)
-            .toList(),
+        serviceUuids:
+            (json['serviceUuids'] as List<dynamic>?)
+                ?.map((e) => e as String)
+                .toList() ??
+            [],
         namePrefix: json['namePrefix'] as String?,
         minRssi: (json['minRssi'] as num?)?.toInt(),
         allowDuplicates: json['allowDuplicates'] as bool? ?? true,

--- a/carp_mobile_sensing/lib/domain/core/device_configurations.dart
+++ b/carp_mobile_sensing/lib/domain/core/device_configurations.dart
@@ -112,6 +112,7 @@ class BLEDevice<TRegistration extends BLEDeviceRegistration>
     extends CamsDevice<TRegistration> {
   /// Advertised service UUIDs to filter for.
   /// String representation of UUIDs, for example: "0000180D-0000-1000-8000-00805f9b34fb"
+  @JsonKey(defaultValue: [])
   List<String> serviceUuids = [];
 
   /// Optional device name filter (substring match, case-insensitive).
@@ -123,6 +124,7 @@ class BLEDevice<TRegistration extends BLEDeviceRegistration>
 
   /// Whether to receive repeated scan results for the same device.
   /// Useful for RSSI updates.
+  @JsonKey(defaultValue: true)
   bool allowDuplicates = true;
 
   /// Scan timeout.
@@ -137,7 +139,7 @@ class BLEDevice<TRegistration extends BLEDeviceRegistration>
     this.allowDuplicates = true,
     this.timeout,
   }) {
-    serviceUuids = serviceUuids ?? [];
+    this.serviceUuids = serviceUuids ?? [];
   }
 
   @override

--- a/carp_mobile_sensing/lib/domain/core/smartphone_deployment.dart
+++ b/carp_mobile_sensing/lib/domain/core/smartphone_deployment.dart
@@ -31,10 +31,34 @@ class SmartphoneDeployment extends PrimaryDeviceDeployment
       Set.from(connectedDevices)..add(deviceConfiguration);
 
   /// The timestamp (in UTC) when this deployment was deployed on this smartphone.
+  // Missing in 1.x deployments, where deployed was nullable.
+  @JsonKey(fromJson: _deployedFromJson)
   DateTime deployed = DateTime.now().toUtc();
 
   /// The status of this study deployment.
+  @JsonKey(fromJson: _statusFromJson)
   StudyDeploymentStatusTypes status = StudyDeploymentStatusTypes.Invited;
+
+  static DateTime _deployedFromJson(String? json) =>
+      json != null ? DateTime.parse(json) : DateTime.now().toUtc();
+
+  // Maps the 1.x StudyStatus enum values to StudyDeploymentStatusTypes.
+  static StudyDeploymentStatusTypes _statusFromJson(String? json) =>
+      switch (json) {
+        'Invited' ||
+        'DeploymentNotStarted' ||
+        'DeploymentStatusAvailable' ||
+        'DeploymentNotAvailable' => StudyDeploymentStatusTypes.Invited,
+        'DeployingDevices' ||
+        'Deploying' ||
+        'AwaitingOtherDeviceRegistrations' ||
+        'AwaitingDeviceDeployment' ||
+        'DeviceDeploymentReceived' ||
+        'RegisteringDevices' => StudyDeploymentStatusTypes.DeployingDevices,
+        'Running' || 'Deployed' => StudyDeploymentStatusTypes.Running,
+        'Stopped' => StudyDeploymentStatusTypes.Stopped,
+        _ => StudyDeploymentStatusTypes.Invited,
+      };
 
   /// Create a new [SmartphoneDeployment].
   ///

--- a/carp_mobile_sensing/lib/infrastructure/sampling_packages/sensors/pedometer_probe.dart
+++ b/carp_mobile_sensing/lib/infrastructure/sampling_packages/sensors/pedometer_probe.dart
@@ -23,3 +23,18 @@ class PedometerProbe extends StreamProbe {
     ),
   );
 }
+
+/// A pedometer probe reporting the total step count since last system boot,
+/// as [StepCount] data.
+///
+/// Kept for backwards compatibility with CAMS 1.x protocols (protocol API
+/// level < 2.0) using the [CarpDataTypes.STEP_COUNT] measure type.
+class StepCountProbe extends StreamProbe {
+  @override
+  Stream<Measurement> get stream => pedometer.Pedometer.stepCountStream.map(
+    (pedometer.StepCount count) => Measurement.fromData(
+      StepCount(steps: count.steps),
+      count.timeStamp.microsecondsSinceEpoch,
+    ),
+  );
+}

--- a/carp_mobile_sensing/lib/infrastructure/sampling_packages/sensors/sensor_package.dart
+++ b/carp_mobile_sensing/lib/infrastructure/sampling_packages/sensors/sensor_package.dart
@@ -67,6 +67,14 @@ class SensorSamplingPackage extends SmartphoneSamplingPackage {
   ///  * No sampling configuration needed.
   static const String STEP_EVENT = '${CarpDataTypes.CARP_NAMESPACE}.stepevent';
 
+  /// Total step count since last system boot from the phone's pedometer.
+  /// Kept for backwards compatibility with CAMS 1.x protocols
+  /// (protocol API level < 2.0) - use [STEP_EVENT] instead.
+  ///  * Event-based measure.
+  ///  * Uses the [Smartphone] device for data collection.
+  ///  * No sampling configuration needed.
+  static const String STEP_COUNT = CarpDataTypes.STEP_COUNT;
+
   @override
   DataTypeSamplingSchemeMap get samplingSchemes =>
       DataTypeSamplingSchemeMap.from([
@@ -115,6 +123,14 @@ class SensorSamplingPackage extends SmartphoneSamplingPackage {
         ),
         DataTypeSamplingScheme(
           CamsDataTypeMetaData(
+            type: STEP_COUNT,
+            displayName: "Step Count",
+            timeType: DataTimeType.POINT,
+            permissions: [Permission.activityRecognition],
+          ),
+        ),
+        DataTypeSamplingScheme(
+          CamsDataTypeMetaData(
             type: AMBIENT_LIGHT,
             displayName: "Ambient Light",
             timeType: DataTimeType.TIME_SPAN,
@@ -141,6 +157,8 @@ class SensorSamplingPackage extends SmartphoneSamplingPackage {
         return GyroscopeProbe();
       case STEP_EVENT:
         return PedometerProbe();
+      case STEP_COUNT:
+        return StepCountProbe();
       case AMBIENT_LIGHT:
         return (Platform.isAndroid) ? LightProbe() : null;
       default:

--- a/carp_mobile_sensing/lib/infrastructure/services/persistence_service.dart
+++ b/carp_mobile_sensing/lib/infrastructure/services/persistence_service.dart
@@ -30,6 +30,7 @@ part of '../../infrastructure.dart';
 /// Files can be accessed via AndroidStudio.
 class PersistenceService {
   static const String DATABASE_NAME = 'carp';
+  static const int DATABASE_VERSION = 2;
   static const String STUDY_TABLE_NAME = 'studies';
   static const String TASK_QUEUE_TABLE_NAME = 'task_queue';
 
@@ -72,35 +73,17 @@ class PersistenceService {
     // open the database - make sure to use the same database across app (re)start
     _database = await openDatabase(
       databaseName,
-      version: 1,
+      version: DATABASE_VERSION,
       singleInstance: true,
       onCreate: (Database db, int version) async {
         // when creating the database, create the tables
-        await db.execute(
-          'CREATE TABLE $STUDY_TABLE_NAME ('
-          '$STUDY_ID_COLUMN TEXT, '
-          '$STUDY_DEPLOYMENT_ID_COLUMN TEXT, '
-          '$DEVICE_ROLE_NAME_COLUMN TEXT, '
-          '$PARTICIPANT_ID_COLUMN TEXT, '
-          '$PARTICIPANT_ROLE_NAME_COLUMN TEXT, '
-          '$CREATED_ON_COLUMN TEXT, '
-          '$UPDATED_ON_COLUMN TEXT, '
-          '$DEPLOYED_ON_COLUMN TEXT, '
-          '$SAMPLING_STATUS_COLUMN TEXT, '
-          '$DEPLOYMENT_STATUS_COLUMN TEXT, '
-          '$DEPLOYMENT_COLUMN TEXT)',
-        );
-
-        await db.execute(
-          'CREATE TABLE $TASK_QUEUE_TABLE_NAME ('
-          '$ID_COLUMN INTEGER PRIMARY KEY, '
-          '$TASK_ID_COLUMN TEXT, '
-          '$STUDY_DEPLOYMENT_ID_COLUMN TEXT, '
-          '$DEVICE_ROLE_NAME_COLUMN TEXT, '
-          '$TASK_COLUMN TEXT)',
-        );
+        await _createStudyTable(db);
+        await _createTaskQueueTable(db);
 
         debug('$runtimeType - $databaseName DB created');
+      },
+      onUpgrade: (Database db, int oldVersion, int newVersion) async {
+        if (oldVersion < 2) await _migrateToV2(db);
       },
     );
 
@@ -113,6 +96,109 @@ class PersistenceService {
     AppTaskController().userTaskEvents.listen((task) => saveUserTask(task));
 
     info('$runtimeType - SQLite DB initialized - file: $databaseName');
+  }
+
+  Future<void> _createStudyTable(Database db) => db.execute(
+    'CREATE TABLE IF NOT EXISTS $STUDY_TABLE_NAME ('
+    '$STUDY_ID_COLUMN TEXT, '
+    '$STUDY_DEPLOYMENT_ID_COLUMN TEXT, '
+    '$DEVICE_ROLE_NAME_COLUMN TEXT, '
+    '$PARTICIPANT_ID_COLUMN TEXT, '
+    '$PARTICIPANT_ROLE_NAME_COLUMN TEXT, '
+    '$CREATED_ON_COLUMN TEXT, '
+    '$UPDATED_ON_COLUMN TEXT, '
+    '$DEPLOYED_ON_COLUMN TEXT, '
+    '$SAMPLING_STATUS_COLUMN TEXT, '
+    '$DEPLOYMENT_STATUS_COLUMN TEXT, '
+    '$DEPLOYMENT_COLUMN TEXT)',
+  );
+
+  Future<void> _createTaskQueueTable(Database db) => db.execute(
+    'CREATE TABLE IF NOT EXISTS $TASK_QUEUE_TABLE_NAME ('
+    '$ID_COLUMN INTEGER PRIMARY KEY, '
+    '$TASK_ID_COLUMN TEXT, '
+    '$STUDY_DEPLOYMENT_ID_COLUMN TEXT, '
+    '$DEVICE_ROLE_NAME_COLUMN TEXT, '
+    '$TASK_COLUMN TEXT)',
+  );
+
+  /// Migrate a database created with version 1 to version 2.
+  ///
+  /// CAMS 1.x databases also used version 1, so the actual schema is
+  /// inspected to determine what needs to be migrated.
+  Future<void> _migrateToV2(Database db) async {
+    await _createStudyTable(db);
+    await _createTaskQueueTable(db);
+
+    // 1.x did not have a device role name column in the task queue.
+    final columns = await db.rawQuery(
+      'PRAGMA table_info($TASK_QUEUE_TABLE_NAME)',
+    );
+    if (!columns.any((column) => column['name'] == DEVICE_ROLE_NAME_COLUMN)) {
+      await db.execute(
+        'ALTER TABLE $TASK_QUEUE_TABLE_NAME '
+        'ADD COLUMN $DEVICE_ROLE_NAME_COLUMN TEXT',
+      );
+
+      // Backfill the new column from the saved task snapshots.
+      final tasks = await db.query(
+        TASK_QUEUE_TABLE_NAME,
+        columns: [ID_COLUMN, TASK_COLUMN],
+      );
+      for (final task in tasks) {
+        try {
+          final snapshot =
+              json.decode(task[TASK_COLUMN] as String) as Map<String, dynamic>;
+          await db.update(
+            TASK_QUEUE_TABLE_NAME,
+            {DEVICE_ROLE_NAME_COLUMN: snapshot['deviceRoleName']},
+            where: '$ID_COLUMN = ?',
+            whereArgs: [task[ID_COLUMN]],
+          );
+        } catch (exception) {
+          warning(
+            '$runtimeType - Failed to migrate task queue entry - $exception',
+          );
+        }
+      }
+    }
+
+    // 1.x stored studies in a 'deployment' table. Copy the columns which map
+    // to the new schema. The 1.x deployment_status column (an enum index)
+    // has no 2.x equivalent and is not migrated.
+    final tables = await db.rawQuery(
+      "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'deployment'",
+    );
+    if (tables.isNotEmpty) {
+      try {
+        await db.execute(
+          'INSERT INTO $STUDY_TABLE_NAME ('
+          '$STUDY_ID_COLUMN, '
+          '$STUDY_DEPLOYMENT_ID_COLUMN, '
+          '$DEVICE_ROLE_NAME_COLUMN, '
+          '$PARTICIPANT_ID_COLUMN, '
+          '$PARTICIPANT_ROLE_NAME_COLUMN, '
+          '$CREATED_ON_COLUMN, '
+          '$UPDATED_ON_COLUMN, '
+          '$DEPLOYED_ON_COLUMN, '
+          '$DEPLOYMENT_COLUMN) '
+          'SELECT '
+          '$STUDY_ID_COLUMN, '
+          '$STUDY_DEPLOYMENT_ID_COLUMN, '
+          '$DEVICE_ROLE_NAME_COLUMN, '
+          '$PARTICIPANT_ID_COLUMN, '
+          '$PARTICIPANT_ROLE_NAME_COLUMN, '
+          'updated_at, updated_at, deployed_at, '
+          '$DEPLOYMENT_COLUMN '
+          'FROM deployment',
+        );
+        await db.execute('DROP TABLE deployment');
+      } catch (exception) {
+        warning('$runtimeType - Failed to migrate studies - $exception');
+      }
+    }
+
+    debug('$runtimeType - $databaseName DB migrated to version 2');
   }
 
   /// Close the persistence layer. After close is called, no deployment can be

--- a/carp_mobile_sensing/lib/runtime/study_controller.dart
+++ b/carp_mobile_sensing/lib/runtime/study_controller.dart
@@ -266,8 +266,13 @@ class SmartphoneStudyController {
 
       // Also update local deployment information about the connected device registrations,
       // so that it is in sync with the deployment service.
-      if (device is! PrimaryDeviceConfiguration) {
-        deployment?.connectedDeviceRegistrations[deviceRoleName] = registration;
+      // Reassign instead of mutating in place: the map may be the unmodifiable
+      // `const {}` default when no registrations were deserialized.
+      if (device is! PrimaryDeviceConfiguration && deployment != null) {
+        deployment!.connectedDeviceRegistrations = {
+          ...deployment!.connectedDeviceRegistrations,
+          deviceRoleName: registration,
+        };
       }
       study.deploymentStatusReceived(deploymentStatus);
     } catch (error) {

--- a/carp_mobile_sensing/pubspec.yaml
+++ b/carp_mobile_sensing/pubspec.yaml
@@ -71,3 +71,4 @@ dev_dependencies:
   json_serializable: any
   test: any
   flutter_lints: any
+  sqflite_common_ffi: any

--- a/carp_mobile_sensing/test/api_level_1_compatibility_test.dart
+++ b/carp_mobile_sensing/test/api_level_1_compatibility_test.dart
@@ -1,0 +1,143 @@
+import 'package:carp_core/carp_core.dart' hide Smartphone, BLEHeartRateDevice;
+import 'package:carp_mobile_sensing/carp_mobile_sensing.dart';
+import 'package:test/test.dart';
+
+/// Tests that protocols and deployments created with CAMS 1.x
+/// (protocol API level < 2.0) - where devices used the carp_core device
+/// namespace - still can be deserialized into the CAMS 2.x domain classes.
+void main() {
+  setUp(() {
+    CarpMobileSensing.ensureInitialized();
+  });
+
+  group('API Level 1.x Backwards Compatibility', () {
+    test(' - 1.x smartphone configuration', () {
+      final device = PrimaryDeviceConfiguration.fromJson({
+        '__type': '${DeviceConfiguration.DEVICE_NAMESPACE}.Smartphone',
+        'roleName': 'Primary Phone',
+        'isOptional': false,
+        'defaultSamplingConfiguration': <String, dynamic>{},
+        'isPrimaryDevice': true,
+      });
+
+      expect(device, isA<Smartphone>());
+      expect(device.roleName, 'Primary Phone');
+      expect(device.type, Smartphone.DEVICE_TYPE);
+    });
+
+    test(' - 1.x smartphone device registration', () {
+      final registration = DeviceRegistration.fromJson({
+        '__type':
+            '${DeviceConfiguration.DEVICE_NAMESPACE}.SmartphoneDeviceRegistration',
+        'deviceId': '123',
+        'registrationCreatedOn': '2025-10-23T07:46:11.643113Z',
+        'platform': 'Android',
+        'deviceModel': 'Pixel 7',
+        'sdk': '34',
+      });
+
+      expect(registration, isA<SmartphoneRegistration>());
+      expect((registration as SmartphoneRegistration).platform, 'Android');
+      expect(registration.deviceId, '123');
+    });
+
+    test(' - 1.x BLE heart rate device w/o scan configuration', () {
+      final device = DeviceConfiguration.fromJson({
+        '__type': '${DeviceConfiguration.DEVICE_NAMESPACE}.BLEHeartRateDevice',
+        'roleName': 'HR Monitor',
+        'isOptional': true,
+        'defaultSamplingConfiguration': <String, dynamic>{},
+      });
+
+      expect(device, isA<BLEHeartRateDevice>());
+      expect((device as BLEHeartRateDevice).serviceUuids, isEmpty);
+      expect(device.allowDuplicates, true);
+    });
+
+    test(' - 1.x study protocol w. old device namespace and measure types',
+        () {
+      final protocol = SmartphoneStudyProtocol.fromJson({
+        'applicationData': {
+          'studyDescription': {
+            '__type': 'StudyDescription',
+            'title': 'study.description.title',
+            'description': 'study.description.description',
+            'purpose': 'study.description.purpose',
+          },
+        },
+        'id': '71b71133-ebbf-436c-851f-73cac1df3d36',
+        'createdOn': '2025-10-23T07:46:11.643113Z',
+        'version': 0,
+        'description': 'study.description.description',
+        'ownerId': '979b408d-784e-4b1b-bb1e-ff9204e072f3',
+        'name': 'CARP Demo Protocol',
+        'participantRoles': [
+          {'role': 'Participant', 'isOptional': false},
+        ],
+        'primaryDevices': [
+          {
+            '__type': '${DeviceConfiguration.DEVICE_NAMESPACE}.Smartphone',
+            'roleName': 'Primary Phone',
+            'isOptional': false,
+            'defaultSamplingConfiguration': <String, dynamic>{},
+            'isPrimaryDevice': true,
+          },
+        ],
+        'connectedDevices': <Map<String, dynamic>>[],
+        'connections': <Map<String, dynamic>>[],
+        'assignedDevices': <String, dynamic>{},
+        'tasks': [
+          {
+            '__type': 'dk.cachet.carp.common.application.tasks.BackgroundTask',
+            'name': 'Task #11',
+            'measures': [
+              {
+                '__type':
+                    'dk.cachet.carp.common.application.tasks.Measure.DataStream',
+                'type': 'dk.cachet.carp.stepcount',
+              },
+              {
+                '__type':
+                    'dk.cachet.carp.common.application.tasks.Measure.DataStream',
+                'type': 'dk.cachet.carp.heartbeat',
+              },
+            ],
+          },
+        ],
+        'triggers': {
+          '0': {
+            '__type':
+                'dk.cachet.carp.common.application.triggers.ImmediateTrigger',
+            'sourceDeviceRoleName': 'Primary Phone',
+          },
+        },
+        'taskControls': [
+          {
+            'triggerId': 0,
+            'taskName': 'Task #11',
+            'destinationDeviceRoleName': 'Primary Phone',
+            'control': 'Start',
+          },
+        ],
+        'expectedParticipantData': <Map<String, dynamic>>[],
+      });
+
+      expect(protocol.primaryDevice, isA<Smartphone>());
+      expect(protocol.primaryDevice.type, Smartphone.DEVICE_TYPE);
+
+      // a 1.x protocol has no API level specified
+      expect(protocol.protocolApiLevel, isNull);
+    });
+
+    test(' - 1.x step count measure type', () {
+      expect(
+        SensorSamplingPackage().samplingSchemes.types,
+        contains(SensorSamplingPackage.STEP_COUNT),
+      );
+      expect(
+        SensorSamplingPackage().create(SensorSamplingPackage.STEP_COUNT),
+        isA<StepCountProbe>(),
+      );
+    });
+  });
+}

--- a/carp_mobile_sensing/test/json/cams_1.x_study_deployment.json
+++ b/carp_mobile_sensing/test/json/cams_1.x_study_deployment.json
@@ -1,0 +1,302 @@
+{
+    "applicationData": {
+        "studyDescription": {
+            "__type": "StudyDescription",
+            "title": "A Test",
+            "description": "A testing protocol",
+            "purpose": "Testing",
+            "responsible": {
+                "__type": "StudyResponsible",
+                "id": "abc",
+                "name": "Alex B. Christensen",
+                "title": "professor",
+                "email": "abc@dtu.dk",
+                "address": "Ørsteds Plads",
+                "affiliation": "Technical University of Denmark"
+            }
+        },
+        "dataEndPoint": {
+            "__type": "SQLiteDataEndPoint",
+            "type": "SQLITE",
+            "dataFormat": "dk.cachet.carp"
+        },
+        "applicationData": {
+            "uiTheme": "black"
+        }
+    },
+    "deviceConfiguration": {
+        "__type": "dk.cachet.carp.common.application.devices.Smartphone",
+        "roleName": "phone",
+        "defaultSamplingConfiguration": {},
+        "isPrimaryDevice": true
+    },
+    "registration": {
+        "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
+        "deviceId": "7ccfb520-1832-1cc4-a0b9-47ffe74c1c2a",
+        "deviceDisplayName": null,
+        "registrationCreatedOn": "2023-09-04T20:31:36.550766Z"
+    },
+    "connectedDevices": [
+        {
+            "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceConfiguration",
+            "roleName": "eSense",
+            "defaultSamplingConfiguration": {}
+        }
+    ],
+    "connectedDeviceRegistrations": {},
+    "tasks": [
+        {
+            "__type": "dk.cachet.carp.common.application.tasks.BackgroundTask",
+            "name": "Task #7",
+            "measures": [
+                {
+                    "__type": "dk.cachet.carp.common.application.tasks.Measure.DataStream",
+                    "type": "dk.cachet.carp.heartbeat"
+                },
+                {
+                    "__type": "dk.cachet.carp.common.application.tasks.Measure.DataStream",
+                    "type": "dk.cachet.carp.error"
+                },
+                {
+                    "__type": "dk.cachet.carp.common.application.tasks.Measure.DataStream",
+                    "type": "dk.cachet.carp.triggeredtask"
+                },
+                {
+                    "__type": "dk.cachet.carp.common.application.tasks.Measure.DataStream",
+                    "type": "dk.cachet.carp.completedtask"
+                }
+            ]
+        },
+        {
+            "__type": "dk.cachet.carp.common.application.tasks.BackgroundTask",
+            "name": "Task #8",
+            "measures": [
+                {
+                    "__type": "dk.cachet.carp.common.application.tasks.Measure.DataStream",
+                    "type": "dk.cachet.carp.heartbeat"
+                },
+                {
+                    "__type": "dk.cachet.carp.common.application.tasks.Measure.DataStream",
+                    "type": "dk.cachet.carp.triggeredtask"
+                },
+                {
+                    "__type": "dk.cachet.carp.common.application.tasks.Measure.DataStream",
+                    "type": "dk.cachet.carp.completedtask"
+                }
+            ]
+        },
+        {
+            "__type": "dk.cachet.carp.common.application.tasks.BackgroundTask",
+            "name": "Start measures",
+            "measures": [
+                {
+                    "__type": "dk.cachet.carp.common.application.tasks.Measure.DataStream",
+                    "type": "dk.cachet.carp.light"
+                },
+                {
+                    "__type": "dk.cachet.carp.common.application.tasks.Measure.DataStream",
+                    "type": "dk.cachet.carp.gps"
+                },
+                {
+                    "__type": "dk.cachet.carp.common.application.tasks.Measure.DataStream",
+                    "type": "dk.cachet.carp.steps"
+                }
+            ]
+        },
+        {
+            "__type": "dk.cachet.carp.common.application.tasks.BackgroundTask",
+            "name": "Task #9",
+            "measures": [
+                {
+                    "__type": "dk.cachet.carp.common.application.tasks.Measure.DataStream",
+                    "type": "dk.cachet.carp.deviceinformation"
+                },
+                {
+                    "__type": "dk.cachet.carp.common.application.tasks.Measure.DataStream",
+                    "type": "dk.cachet.carp.freememory"
+                },
+                {
+                    "__type": "dk.cachet.carp.common.application.tasks.Measure.DataStream",
+                    "type": "dk.cachet.carp.batterystate"
+                },
+                {
+                    "__type": "dk.cachet.carp.common.application.tasks.Measure.DataStream",
+                    "type": "dk.cachet.carp.screenevent"
+                },
+                {
+                    "__type": "dk.cachet.carp.common.application.tasks.Measure.DataStream",
+                    "type": "dk.cachet.carp.timezone"
+                },
+                {
+                    "__type": "dk.cachet.carp.common.application.tasks.Measure.DataStream",
+                    "type": "dk.cachet.carp.acceleration"
+                },
+                {
+                    "__type": "dk.cachet.carp.common.application.tasks.Measure.DataStream",
+                    "type": "dk.cachet.carp.nongravitationalacceleration"
+                },
+                {
+                    "__type": "dk.cachet.carp.common.application.tasks.Measure.DataStream",
+                    "type": "dk.cachet.carp.rotation"
+                },
+                {
+                    "__type": "dk.cachet.carp.common.application.tasks.Measure.DataStream",
+                    "type": "dk.cachet.carp.stepcount"
+                },
+                {
+                    "__type": "dk.cachet.carp.common.application.tasks.Measure.DataStream",
+                    "type": "dk.cachet.carp.magneticfield"
+                },
+                {
+                    "__type": "dk.cachet.carp.common.application.tasks.Measure.DataStream",
+                    "type": "dk.cachet.carp.ambientlight"
+                }
+            ]
+        },
+        {
+            "__type": "dk.cachet.carp.common.application.tasks.BackgroundTask",
+            "name": "Task #10",
+            "measures": [
+                {
+                    "__type": "dk.cachet.carp.common.application.tasks.Measure.DataStream",
+                    "type": "dk.cachet.carp.deviceinformation"
+                }
+            ]
+        },
+        {
+            "__type": "dk.cachet.carp.common.application.tasks.AppTask",
+            "name": "Task #11",
+            "measures": [
+                {
+                    "__type": "dk.cachet.carp.common.application.tasks.Measure.DataStream",
+                    "type": "dk.cachet.carp.ambientlight"
+                },
+                {
+                    "__type": "dk.cachet.carp.common.application.tasks.Measure.DataStream",
+                    "type": "dk.cachet.carp.stepcount"
+                }
+            ],
+            "type": "one_time_sensing",
+            "title": "Location, Weather & Air Quality",
+            "description": "Collect location, weather and air quality",
+            "instructions": "",
+            "notification": false
+        },
+        {
+            "__type": "dk.cachet.carp.common.application.tasks.BackgroundTask",
+            "name": "Task #12",
+            "measures": [
+                {
+                    "__type": "dk.cachet.carp.common.application.tasks.Measure.DataStream",
+                    "type": "dk.cachet.carp.freememory"
+                },
+                {
+                    "__type": "dk.cachet.carp.common.application.tasks.Measure.DataStream",
+                    "type": "dk.cachet.carp.ambientlight"
+                }
+            ]
+        }
+    ],
+    "triggers": {
+        "0": {
+            "__type": "dk.cachet.carp.common.application.triggers.NoOpTrigger",
+            "sourceDeviceRoleName": "Primary Phone"
+        },
+        "1": {
+            "__type": "dk.cachet.carp.common.application.triggers.NoOpTrigger",
+            "sourceDeviceRoleName": "eSense"
+        },
+        "2": {
+            "__type": "dk.cachet.carp.common.application.triggers.TriggerConfiguration",
+            "sourceDeviceRoleName": "Primary Phone"
+        },
+        "3": {
+            "__type": "dk.cachet.carp.common.application.triggers.ImmediateTrigger",
+            "sourceDeviceRoleName": "Primary Phone"
+        },
+        "4": {
+            "__type": "dk.cachet.carp.common.application.triggers.OneTimeTrigger",
+            "sourceDeviceRoleName": "Primary Phone"
+        },
+        "5": {
+            "__type": "dk.cachet.carp.common.application.triggers.ImmediateTrigger",
+            "sourceDeviceRoleName": "Primary Phone"
+        },
+        "6": {
+            "__type": "dk.cachet.carp.common.application.triggers.UserTaskTrigger",
+            "sourceDeviceRoleName": "Primary Phone",
+            "taskName": "Task #11",
+            "triggerCondition": "done"
+        },
+        "7": {
+            "__type": "dk.cachet.carp.common.application.triggers.ImmediateTrigger",
+            "sourceDeviceRoleName": "eSense"
+        }
+    },
+    "taskControls": [
+        {
+            "triggerId": 0,
+            "taskName": "Task #7",
+            "destinationDeviceRoleName": "Primary Phone",
+            "control": "Start"
+        },
+        {
+            "triggerId": 1,
+            "taskName": "Task #8",
+            "destinationDeviceRoleName": "eSense",
+            "control": "Start"
+        },
+        {
+            "triggerId": 2,
+            "taskName": "Start measures",
+            "destinationDeviceRoleName": "Primary Phone",
+            "control": "Start"
+        },
+        {
+            "triggerId": 3,
+            "taskName": "Task #9",
+            "destinationDeviceRoleName": "Primary Phone",
+            "control": "Start"
+        },
+        {
+            "triggerId": 4,
+            "taskName": "Task #10",
+            "destinationDeviceRoleName": "Primary Phone",
+            "control": "Start"
+        },
+        {
+            "triggerId": 5,
+            "taskName": "Task #11",
+            "destinationDeviceRoleName": "Primary Phone",
+            "control": "Start"
+        },
+        {
+            "triggerId": 6,
+            "taskName": "Task #11",
+            "destinationDeviceRoleName": "Primary Phone",
+            "control": "Start"
+        },
+        {
+            "triggerId": 7,
+            "taskName": "Task #12",
+            "destinationDeviceRoleName": "eSense",
+            "control": "Start"
+        }
+    ],
+    "expectedParticipantData": [
+        {
+            "attribute": {
+                "__type": "dk.cachet.carp.common.application.users.ParticipantAttribute.DefaultParticipantAttribute",
+                "inputDataType": "dk.cachet.carp.sex"
+            },
+            "assignedTo": {
+                "__type": "dk.cachet.carp.common.application.users.AssignedTo.Roles",
+                "roleNames": [
+                    "Participant"
+                ]
+            }
+        }
+    ],
+    "studyDeploymentId": "1234",
+    "status": "DeploymentNotStarted"
+}

--- a/carp_mobile_sensing/test/json/study_deployment.json
+++ b/carp_mobile_sensing/test/json/study_deployment.json
@@ -34,8 +34,8 @@
  },
  "registration": {
   "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
-  "deviceId": "593f4f23-dea6-4811-8bbf-48a32412cfaf",
-  "registrationCreatedOn": "2026-04-01T16:20:44.570852Z"
+  "deviceId": "7ba9d436-39ea-42cf-8487-b8e12d272aa6",
+  "registrationCreatedOn": "2026-06-11T06:36:21.116452Z"
  },
  "connectedDevices": [
   {
@@ -159,6 +159,10 @@
     {
      "__type": "dk.cachet.carp.common.application.tasks.Measure.DataStream",
      "type": "dk.cachet.carp.stepevent"
+    },
+    {
+     "__type": "dk.cachet.carp.common.application.tasks.Measure.DataStream",
+     "type": "dk.cachet.carp.stepcount"
     },
     {
      "__type": "dk.cachet.carp.common.application.tasks.Measure.DataStream",
@@ -331,6 +335,6 @@
   }
  ],
  "studyDeploymentId": "1234",
- "deployed": "2026-04-01T16:20:44.570839Z",
+ "deployed": "2026-06-11T06:36:21.116445Z",
  "status": "Invited"
 }

--- a/carp_mobile_sensing/test/json/study_protocol.json
+++ b/carp_mobile_sensing/test/json/study_protocol.json
@@ -26,8 +26,8 @@
    "uiTheme": "black"
   }
  },
- "id": "73de02da-5757-421e-97c5-53663523c84a",
- "createdOn": "2026-04-01T16:20:44.527601Z",
+ "id": "fff5022a-af09-4a4d-9019-9509d24fc87d",
+ "createdOn": "2026-06-11T06:36:21.093751Z",
  "version": 0,
  "ownerId": "user@dtu.dk",
  "name": "patient_tracking",
@@ -174,6 +174,10 @@
     {
      "__type": "dk.cachet.carp.common.application.tasks.Measure.DataStream",
      "type": "dk.cachet.carp.stepevent"
+    },
+    {
+     "__type": "dk.cachet.carp.common.application.tasks.Measure.DataStream",
+     "type": "dk.cachet.carp.stepcount"
     },
     {
      "__type": "dk.cachet.carp.common.application.tasks.Measure.DataStream",

--- a/carp_mobile_sensing/test/persistence_service_migration_test.dart
+++ b/carp_mobile_sensing/test/persistence_service_migration_test.dart
@@ -1,0 +1,118 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:carp_mobile_sensing/carp_mobile_sensing.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+import 'package:test/test.dart';
+
+/// Tests that a database created with CAMS 1.x is migrated to the 2.x schema
+/// when the [PersistenceService] is initialized.
+void main() {
+  sqfliteFfiInit();
+  databaseFactory = databaseFactoryFfi;
+
+  const deploymentId = '14cd5547-2fcd-4685-9b12-2d9e21b7b1d8';
+  const roleName = 'phone';
+
+  setUpAll(() {
+    CarpMobileSensing.ensureInitialized();
+  });
+
+  test('1.x database is migrated to the 2.x schema', () async {
+    final databaseName =
+        '${await getDatabasesPath()}/${PersistenceService.DATABASE_NAME}.db';
+    await deleteDatabase(databaseName);
+
+    final deploymentJson = File(
+      'test/json/cams_1.x_study_deployment.json',
+    ).readAsStringSync();
+
+    final snapshot = UserTaskSnapshot(
+      '7fb3fd47-f61b-48c5-add2-39d4762bfc67',
+      AppTask(type: 'survey', name: 'Task #1'),
+      UserTaskState.enqueued,
+      DateTime.now(),
+      DateTime.now(),
+      null,
+      false,
+      deploymentId,
+      roleName,
+    );
+
+    // Create a database with the 1.x schema and content.
+    var db = await openDatabase(
+      databaseName,
+      version: 1,
+      onCreate: (Database db, int version) async {
+        await db.execute(
+          'CREATE TABLE deployment ('
+          'study_id TEXT, '
+          'study_deployment_id TEXT PRIMARY KEY, '
+          'device_role_name TEXT, '
+          'participant_id TEXT, '
+          'participant_role_name TEXT, '
+          'deployment_status INTEGER, '
+          'updated_at TEXT, '
+          'deployed_at TEXT, '
+          'deployment TEXT)',
+        );
+        await db.execute(
+          'CREATE TABLE task_queue ('
+          'id INTEGER PRIMARY KEY, '
+          'study_deployment_id TEXT, '
+          'task_id TEXT, '
+          'task TEXT)',
+        );
+      },
+    );
+    await db.insert('deployment', {
+      'study_id': 'study-1',
+      'study_deployment_id': deploymentId,
+      'device_role_name': roleName,
+      'participant_id': 'participant-1',
+      'participant_role_name': 'Participant',
+      'deployment_status': 4,
+      'updated_at': '2023-09-04T20:31:36.550766Z',
+      'deployed_at': '2023-09-04T20:31:36.550766Z',
+      'deployment': deploymentJson,
+    });
+    await db.insert('task_queue', {
+      'study_deployment_id': deploymentId,
+      'task_id': snapshot.id,
+      'task': jsonEncode(snapshot),
+    });
+    await db.close();
+
+    // Initializing the persistence service migrates the database.
+    final persistence = PersistenceService();
+    await persistence.init();
+
+    final studies = await persistence.getAllStudies();
+    expect(studies.length, 1);
+
+    final study = studies.first;
+    expect(study.studyId, 'study-1');
+    expect(study.studyDeploymentId, deploymentId);
+    expect(study.deviceRoleName, roleName);
+    expect(study.participantId, 'participant-1');
+    expect(study.participantRoleName, 'Participant');
+    expect(study.deployment, isNotNull);
+    expect(study.deployment!.deviceConfiguration.roleName, roleName);
+
+    // Querying tasks per study requires the backfilled device role name.
+    final tasks = await persistence.getUserTasks(study);
+    expect(tasks.length, 1);
+    expect(tasks.first.id, snapshot.id);
+    expect(tasks.first.deviceRoleName, roleName);
+
+    await persistence.close();
+
+    // The 1.x deployment table is removed after migration.
+    db = await openDatabase(databaseName);
+    final tables = await db.rawQuery(
+      "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'deployment'",
+    );
+    expect(tables, isEmpty);
+    await db.close();
+  });
+}

--- a/packages/carp_context_package/lib/src/context_package.dart
+++ b/packages/carp_context_package/lib/src/context_package.dart
@@ -89,6 +89,21 @@ class ContextSamplingPackage extends SmartphoneSamplingPackage {
       GeoPosition(1.1, 1.1),
     ]);
 
+    // Backwards compatibility with CAMS 1.x (protocol API level < 2.0) where
+    // these services used the carp_core device namespace.
+    FromJsonFactory().register(
+      LocationService(),
+      type: '${DeviceConfiguration.DEVICE_NAMESPACE}.LocationService',
+    );
+    FromJsonFactory().register(
+      WeatherService(apiKey: ''),
+      type: '${DeviceConfiguration.DEVICE_NAMESPACE}.WeatherService',
+    );
+    FromJsonFactory().register(
+      AirQualityService(apiKey: ''),
+      type: '${DeviceConfiguration.DEVICE_NAMESPACE}.AirQualityService',
+    );
+
     // register all data types
     FromJsonFactory().registerAll([
       Activity(type: ActivityType.UNKNOWN, confidence: 0),

--- a/packages/carp_context_package/test/api_level_1_compatibility_test.dart
+++ b/packages/carp_context_package/test/api_level_1_compatibility_test.dart
@@ -1,0 +1,67 @@
+import 'package:test/test.dart';
+
+import 'package:carp_core/carp_core.dart' hide Smartphone;
+import 'package:carp_mobile_sensing/carp_mobile_sensing.dart';
+import 'package:carp_context_package/carp_context_package.dart';
+
+/// Tests that protocols created with CAMS 1.x (protocol API level < 2.0) -
+/// where the context services used the carp_core device namespace - still
+/// can be deserialized into the CAMS 2.x classes.
+void main() {
+  setUp(() {
+    CarpMobileSensing.ensureInitialized();
+    SamplingPackageRegistry().register(ContextSamplingPackage());
+  });
+
+  group('API Level 1.x Backwards Compatibility', () {
+    test(' - 1.x location service', () {
+      final device = DeviceConfiguration.fromJson({
+        '__type': '${DeviceConfiguration.DEVICE_NAMESPACE}.LocationService',
+        'roleName': 'Location Service',
+        'isOptional': true,
+        'defaultSamplingConfiguration': <String, dynamic>{},
+        'accuracy': 'balanced',
+        'distance': 10.0,
+        'interval': 60000000,
+        'notificationOnTapBringToFront': false,
+      });
+
+      expect(device, isA<LocationService>());
+      final service = device as LocationService;
+      expect(service.type, LocationService.DEVICE_TYPE);
+      expect(service.accuracy, GeolocationAccuracy.balanced);
+      expect(service.distance, 10.0);
+      expect(service.interval, const Duration(minutes: 1));
+    });
+
+    test(' - 1.x weather service', () {
+      final device = DeviceConfiguration.fromJson({
+        '__type': '${DeviceConfiguration.DEVICE_NAMESPACE}.WeatherService',
+        'roleName': 'Weather Service',
+        'isOptional': true,
+        'defaultSamplingConfiguration': <String, dynamic>{},
+        'apiKey': '12b6e28582eb9298577c734a31ba9f4f',
+      });
+
+      expect(device, isA<WeatherService>());
+      final service = device as WeatherService;
+      expect(service.type, WeatherService.DEVICE_TYPE);
+      expect(service.apiKey, '12b6e28582eb9298577c734a31ba9f4f');
+    });
+
+    test(' - 1.x air quality service', () {
+      final device = DeviceConfiguration.fromJson({
+        '__type': '${DeviceConfiguration.DEVICE_NAMESPACE}.AirQualityService',
+        'roleName': 'Air Quality Service',
+        'isOptional': true,
+        'defaultSamplingConfiguration': <String, dynamic>{},
+        'apiKey': '9e538456b2b85c92647d8b65090e29f957638c77',
+      });
+
+      expect(device, isA<AirQualityService>());
+      final service = device as AirQualityService;
+      expect(service.type, AirQualityService.DEVICE_TYPE);
+      expect(service.apiKey, '9e538456b2b85c92647d8b65090e29f957638c77');
+    });
+  });
+}

--- a/packages/carp_esense_package/lib/esense.g.dart
+++ b/packages/carp_esense_package/lib/esense.g.dart
@@ -60,12 +60,14 @@ ESenseDevice _$ESenseDeviceFromJson(Map<String, dynamic> json) =>
               SamplingConfiguration.fromJson(e as Map<String, dynamic>),
             ),
           )
-      ..serviceUuids = (json['serviceUuids'] as List<dynamic>)
-          .map((e) => e as String)
-          .toList()
+      ..serviceUuids =
+          (json['serviceUuids'] as List<dynamic>?)
+              ?.map((e) => e as String)
+              .toList() ??
+          []
       ..namePrefix = json['namePrefix'] as String?
       ..minRssi = (json['minRssi'] as num?)?.toInt()
-      ..allowDuplicates = json['allowDuplicates'] as bool
+      ..allowDuplicates = json['allowDuplicates'] as bool? ?? true
       ..timeout = json['timeout'] == null
           ? null
           : Duration(microseconds: (json['timeout'] as num).toInt());

--- a/packages/carp_esense_package/lib/esense_package.dart
+++ b/packages/carp_esense_package/lib/esense_package.dart
@@ -87,6 +87,13 @@ class ESenseSamplingPackage implements SamplingPackage {
       BLEDeviceRegistration(bleAddress: ''),
     ]);
 
+    // Backwards compatibility with CAMS 1.x (protocol API level < 2.0) where
+    // the eSense device used the carp_core device namespace.
+    FromJsonFactory().register(
+      ESenseDevice(),
+      type: '${DeviceConfiguration.DEVICE_NAMESPACE}.ESenseDevice',
+    );
+
     // register all data types
     FromJsonFactory().registerAll([
       ESenseButton(deviceName: 'deviceName', pressed: true),

--- a/packages/carp_health_package/lib/health_package.dart
+++ b/packages/carp_health_package/lib/health_package.dart
@@ -121,6 +121,14 @@ class HealthSamplingPackage extends SmartphoneSamplingPackage {
         platform: HealthPlatform.APPLE_HEALTH,
       ),
     ]);
+
+    // Backwards compatibility with CAMS 1.x (protocol API level < 2.0) where
+    // the health service used the carp_core device namespace.
+    FromJsonFactory().register(
+      HealthService(),
+      type: '${DeviceConfiguration.DEVICE_NAMESPACE}.HealthService',
+    );
+
     AppTaskController().registerUserTaskFactory(HealthUserTaskFactory());
   }
 

--- a/packages/carp_movesense_package/lib/carp_movesense_package.dart
+++ b/packages/carp_movesense_package/lib/carp_movesense_package.dart
@@ -121,6 +121,13 @@ class MovesenseSamplingPackage implements SamplingPackage {
       MovesenseTemperature(0, 0),
       MovesenseIMU(0, [], [], []),
     ]);
+
+    // Backwards compatibility with CAMS 1.x (protocol API level < 2.0) where
+    // the Movesense device used the carp_core device namespace.
+    FromJsonFactory().register(
+      MovesenseDevice(),
+      type: '${DeviceConfiguration.DEVICE_NAMESPACE}.MovesenseDevice',
+    );
   }
 
   @override

--- a/packages/carp_movesense_package/lib/carp_movesense_package.g.dart
+++ b/packages/carp_movesense_package/lib/carp_movesense_package.g.dart
@@ -227,12 +227,14 @@ MovesenseDevice _$MovesenseDeviceFromJson(Map<String, dynamic> json) =>
               SamplingConfiguration.fromJson(e as Map<String, dynamic>),
             ),
           )
-      ..serviceUuids = (json['serviceUuids'] as List<dynamic>)
-          .map((e) => e as String)
-          .toList()
+      ..serviceUuids =
+          (json['serviceUuids'] as List<dynamic>?)
+              ?.map((e) => e as String)
+              .toList() ??
+          []
       ..namePrefix = json['namePrefix'] as String?
       ..minRssi = (json['minRssi'] as num?)?.toInt()
-      ..allowDuplicates = json['allowDuplicates'] as bool
+      ..allowDuplicates = json['allowDuplicates'] as bool? ?? true
       ..timeout = json['timeout'] == null
           ? null
           : Duration(microseconds: (json['timeout'] as num).toInt());

--- a/packages/carp_movesense_package/test/api_level_1_compatibility_test.dart
+++ b/packages/carp_movesense_package/test/api_level_1_compatibility_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/widgets.dart';
+import 'package:test/test.dart';
+
+import 'package:carp_core/carp_core.dart' hide Smartphone;
+import 'package:carp_mobile_sensing/carp_mobile_sensing.dart';
+import 'package:carp_movesense_package/carp_movesense_package.dart';
+
+/// Tests that protocols created with CAMS 1.x (protocol API level < 2.0) -
+/// where the Movesense device used the carp_core device namespace and had a
+/// (now removed) deviceType property - still can be deserialized into the
+/// CAMS 2.x class.
+void main() {
+  setUpAll(() {
+    WidgetsFlutterBinding.ensureInitialized();
+    CarpMobileSensing.ensureInitialized();
+    SamplingPackageRegistry().register(MovesenseSamplingPackage());
+  });
+
+  group('API Level 1.x Backwards Compatibility', () {
+    test(' - 1.x Movesense device', () {
+      final device = DeviceConfiguration.fromJson({
+        '__type': '${DeviceConfiguration.DEVICE_NAMESPACE}.MovesenseDevice',
+        'roleName': 'Movesense ECG Device',
+        'isOptional': true,
+        'defaultSamplingConfiguration': <String, dynamic>{},
+        'deviceType': 'UNKNOWN',
+      });
+
+      expect(device, isA<MovesenseDevice>());
+      final movesense = device as MovesenseDevice;
+      expect(movesense.type, MovesenseDevice.DEVICE_TYPE);
+      expect(movesense.roleName, 'Movesense ECG Device');
+      expect(movesense.serviceUuids, isEmpty);
+      expect(movesense.allowDuplicates, true);
+    });
+  });
+}

--- a/packages/carp_movesense_package/test/json/protocol.json
+++ b/packages/carp_movesense_package/test/json/protocol.json
@@ -1,6 +1,6 @@
 {
- "id": "5ff66097-078a-4dea-b1d4-56b84340e09c",
- "createdOn": "2026-04-13T11:03:25.621700Z",
+ "id": "00dd2428-3f12-4ed0-89fb-2c6cd095c1cb",
+ "createdOn": "2026-06-11T06:36:40.563759Z",
  "version": 0,
  "ownerId": "alex@uni.dk",
  "name": "Context package test",
@@ -91,6 +91,10 @@
     {
      "__type": "dk.cachet.carp.common.application.tasks.Measure.DataStream",
      "type": "dk.cachet.carp.stepevent"
+    },
+    {
+     "__type": "dk.cachet.carp.common.application.tasks.Measure.DataStream",
+     "type": "dk.cachet.carp.stepcount"
     },
     {
      "__type": "dk.cachet.carp.common.application.tasks.Measure.DataStream",

--- a/packages/carp_movisens_package/lib/carp_movisens_package.dart
+++ b/packages/carp_movisens_package/lib/carp_movisens_package.dart
@@ -112,6 +112,13 @@ class MovisensSamplingPackage implements SamplingPackage {
   void onRegister() {
     FromJsonFactory().register(MovisensDevice());
 
+    // Backwards compatibility with CAMS 1.x (protocol API level < 2.0) where
+    // the Movisens device used the carp_core device namespace.
+    FromJsonFactory().register(
+      MovisensDevice(),
+      type: '${DeviceConfiguration.DEVICE_NAMESPACE}.MovisensDevice',
+    );
+
     // register all data types
     FromJsonFactory().registerAll([
       MovisensStepCount(deviceId: '', type: '', steps: 0),

--- a/packages/carp_movisens_package/lib/carp_movisens_package.g.dart
+++ b/packages/carp_movisens_package/lib/carp_movisens_package.g.dart
@@ -290,12 +290,14 @@ MovisensDevice _$MovisensDeviceFromJson(Map<String, dynamic> json) =>
               SamplingConfiguration.fromJson(e as Map<String, dynamic>),
             ),
           )
-      ..serviceUuids = (json['serviceUuids'] as List<dynamic>)
-          .map((e) => e as String)
-          .toList()
+      ..serviceUuids =
+          (json['serviceUuids'] as List<dynamic>?)
+              ?.map((e) => e as String)
+              .toList() ??
+          []
       ..namePrefix = json['namePrefix'] as String?
       ..minRssi = (json['minRssi'] as num?)?.toInt()
-      ..allowDuplicates = json['allowDuplicates'] as bool
+      ..allowDuplicates = json['allowDuplicates'] as bool? ?? true
       ..timeout = json['timeout'] == null
           ? null
           : Duration(microseconds: (json['timeout'] as num).toInt());

--- a/packages/carp_polar_package/lib/carp_polar_package.dart
+++ b/packages/carp_polar_package/lib/carp_polar_package.dart
@@ -187,6 +187,13 @@ class PolarSamplingPackage implements SamplingPackage {
       PolarPPI(samples: []),
       PolarHR(samples: []),
     ]);
+
+    // Backwards compatibility with CAMS 1.x (protocol API level < 2.0) where
+    // the Polar device used the carp_core device namespace.
+    FromJsonFactory().register(
+      PolarDevice(),
+      type: '${DeviceConfiguration.DEVICE_NAMESPACE}.PolarDevice',
+    );
   }
 
   @override

--- a/packages/carp_polar_package/lib/carp_polar_package.g.dart
+++ b/packages/carp_polar_package/lib/carp_polar_package.g.dart
@@ -275,11 +275,13 @@ PolarDevice _$PolarDeviceFromJson(Map<String, dynamic> json) =>
               SamplingConfiguration.fromJson(e as Map<String, dynamic>),
             ),
           )
-      ..serviceUuids = (json['serviceUuids'] as List<dynamic>)
-          .map((e) => e as String)
-          .toList()
+      ..serviceUuids =
+          (json['serviceUuids'] as List<dynamic>?)
+              ?.map((e) => e as String)
+              .toList() ??
+          []
       ..minRssi = (json['minRssi'] as num?)?.toInt()
-      ..allowDuplicates = json['allowDuplicates'] as bool
+      ..allowDuplicates = json['allowDuplicates'] as bool? ?? true
       ..timeout = json['timeout'] == null
           ? null
           : Duration(microseconds: (json['timeout'] as num).toInt());

--- a/packages/carp_polar_package/test/api_level_1_compatibility_test.dart
+++ b/packages/carp_polar_package/test/api_level_1_compatibility_test.dart
@@ -1,0 +1,34 @@
+import 'package:test/test.dart';
+
+import 'package:carp_core/carp_core.dart' hide Smartphone;
+import 'package:carp_mobile_sensing/carp_mobile_sensing.dart';
+import 'package:carp_polar_package/carp_polar_package.dart';
+
+/// Tests that protocols created with CAMS 1.x (protocol API level < 2.0) -
+/// where the Polar device used the carp_core device namespace and had no
+/// BLE scan configuration - still can be deserialized into the CAMS 2.x class.
+void main() {
+  setUp(() {
+    CarpMobileSensing.ensureInitialized();
+    SamplingPackageRegistry().register(PolarSamplingPackage());
+  });
+
+  group('API Level 1.x Backwards Compatibility', () {
+    test(' - 1.x Polar device', () {
+      final device = DeviceConfiguration.fromJson({
+        '__type': '${DeviceConfiguration.DEVICE_NAMESPACE}.PolarDevice',
+        'roleName': 'Polar HR Sensor',
+        'isOptional': true,
+        'defaultSamplingConfiguration': <String, dynamic>{},
+      });
+
+      expect(device, isA<PolarDevice>());
+      final polar = device as PolarDevice;
+      expect(polar.type, PolarDevice.DEVICE_TYPE);
+      expect(polar.roleName, 'Polar HR Sensor');
+      expect(polar.serviceUuids, isEmpty);
+      expect(polar.namePrefix, 'Polar');
+      expect(polar.allowDuplicates, true);
+    });
+  });
+}

--- a/packages/carp_polar_package/test/json/protocol.json
+++ b/packages/carp_polar_package/test/json/protocol.json
@@ -1,6 +1,6 @@
 {
- "id": "e22ae4cb-be37-4d39-8e3d-5253db0fa811",
- "createdOn": "2026-04-13T10:46:52.808020Z",
+ "id": "0a08390e-e0a0-41c5-9eb8-28e49bd739b9",
+ "createdOn": "2026-06-11T06:39:28.966913Z",
  "version": 0,
  "ownerId": "alex@uni.dk",
  "name": "Context package test",
@@ -92,6 +92,10 @@
     {
      "__type": "dk.cachet.carp.common.application.tasks.Measure.DataStream",
      "type": "dk.cachet.carp.stepevent"
+    },
+    {
+     "__type": "dk.cachet.carp.common.application.tasks.Measure.DataStream",
+     "type": "dk.cachet.carp.stepcount"
     },
     {
      "__type": "dk.cachet.carp.common.application.tasks.Measure.DataStream",


### PR DESCRIPTION
## Problem

Apps upgrading from CAMS 1.x to 2.x hit three independent blockers:

1. **Deserialization.** Protocols and deployments created with CAMS 1.x (protocol API level < 2.0) can no longer be deserialized after the device type rename from `dk.cachet.carp.common.application.devices.*` to `dk.carp.cams.devices.*`. Old JSON throws a `SerializationException` and the protocol fails to load entirely.
2. **SQLite schema.** Both 1.x and 2.x open `carp.db` with database version 1, but 2.x renamed the `deployment` table to `studies` and added a `device_role_name` column to `task_queue`. Since the version never changed, neither `onCreate` nor any upgrade hook runs on a device with an existing 1.x database — every study save fails with `no such table: studies` and every task save throws an unhandled `no such column: device_role_name` exception.
3. **Stored 1.x deployments.** Deployment JSON cached on the phone by 1.x omits the `deployed` timestamp (it was nullable) and uses the 1.x `StudyStatus` enum names, both of which made `SmartphoneDeployment.fromJson` throw even with the type aliases in place.

## Changes

### Deserialization

- Register the 1.x device type names as `fromJson` aliases for the 2.x classes — `Smartphone`, `BLEHeartRateDevice`, `SmartphoneDeviceRegistration`, and the devices in the context, health, polar, movesense, esense, and movisens packages.
- Tolerate missing BLE scan fields (`serviceUuids`, `allowDuplicates`) when deserializing `BLEDevice` configurations, which 1.x JSON does not contain.
- Restore the 1.x `stepcount` measure type and probe, removed in 2.x in favor of `stepevent`.
- `SmartphoneDeployment.fromJson` now defaults `deployed` to now when missing and maps the eleven 1.x `StudyStatus` names onto `StudyDeploymentStatusTypes` (e.g. `Deployed` → `Running`, deployment-in-progress states → `DeployingDevices`).

### Database migration

- Bump `PersistenceService` to database version 2 and add an `onUpgrade` migration which:
  - creates the `studies` table,
  - adds the `device_role_name` column to `task_queue` and backfills it from the saved task snapshots,
  - copies the mappable columns (ids, roles, timestamps, deployment JSON) from the 1.x `deployment` table into `studies` and drops the old table. The 1.x `deployment_status` column (an enum index) has no 2.x equivalent and is not migrated.
- The migration inspects the actual schema before changing it, so a database created by 2.x at version 1 passes through unchanged.

### Runtime

- `SmartphoneStudyController` now reassigns `connectedDeviceRegistrations` instead of mutating it in place — the map may be the unmodifiable `const {}` default when no registrations were deserialized from a 1.x deployment.

## Testing

- New `api_level_1_compatibility_test.dart` in carp_mobile_sensing and the context/polar/movesense packages, deserializing real 1.x JSON.
- New `persistence_service_migration_test.dart` which builds a real 1.x database (old schema, a genuine 1.x deployment JSON fixture, a queued task) and verifies that initializing the `PersistenceService` migrates it: studies and tasks load, the role name is backfilled, and the old table is dropped. Runs on `sqflite_common_ffi` (new dev dependency).
- All new and existing suites pass.
