### PR TITLE
chore: bump versions and changelogs for 1.x compatibility release

### DIFF
--- a/carp_mobile_sensing/CHANGELOG.md
+++ b/carp_mobile_sensing/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 2.1.2
+
+Backwards compatibility with studies created on CAMS 1.x (protocol API level < 2.0), so that apps can upgrade from 1.x to 2.x without losing running deployments.
+
+* Support deserialization of 1.x protocols and deployments, which used the `carp_core` device namespace before the rename to `dk.carp.cams.devices` — the 1.x device type names are now registered as `fromJson` aliases (`Smartphone`, `BLEHeartRateDevice`, `SmartphoneDeviceRegistration`).
+* Tolerate missing BLE scan fields (`serviceUuids`, `allowDuplicates`) and the missing `deployed` / 1.x `status` fields when deserializing 1.x deployments.
+* Restore the 1.x `stepcount` measure type and probe.
+* Migrate the local SQLite database from the 1.x schema to the 2.x schema on first launch (`studies` table and the `device_role_name` column on `task_queue`), instead of failing with `no such table` / `no such column`.
+
 ## 2.1.1 - BREAKING
 
 This release has two new main features: (i) to support adding, running, and removing **multiple studies** to the client manager, and (ii) to **save runtime state persistently** so that sampling of data in all studies will resume effortlessly across app restart. In addition, a set of issues have been addressed, as listed in [Milestone 2.0.0](https://github.com/carp-dk/carp.sensing-flutter/milestone/3?closed=1). The important ones include:

--- a/carp_mobile_sensing/pubspec.yaml
+++ b/carp_mobile_sensing/pubspec.yaml
@@ -1,5 +1,5 @@
 name: carp_mobile_sensing
-version: 2.1.1
+version: 2.1.2
 description: Mobile Sensing Framework for Flutter. A software framework for collecting sensor data from the phone and attached wearable devices via probes. Can be extended.
 
 # Note that the following URLs to GitHub should use the old 'cph-cachet' name. 

--- a/packages/carp_context_package/CHANGELOG.md
+++ b/packages/carp_context_package/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.1
+
+* register the 1.x `LocationService`, `WeatherService`, and `AirQualityService` device types as `fromJson` aliases, for backwards compatibility with studies created on CAMS 1.x (protocol API level < 2.0)
+
 ## 2.0.0
 
 * upgrade to CARP Core and CAMS API level 2.0.0

--- a/packages/carp_context_package/pubspec.yaml
+++ b/packages/carp_context_package/pubspec.yaml
@@ -1,5 +1,5 @@
 name: carp_context_package
-version: 2.0.0
+version: 2.0.1
 description: CARP context sampling package. Samples location, mobility, activity, weather, air-quality, and geofence.
 homepage: https://github.com/cph-cachet/carp.sensing-flutter
 repository: https://github.com/cph-cachet/carp.sensing-flutter/tree/main/packages/carp_context_package

--- a/packages/carp_esense_package/CHANGELOG.md
+++ b/packages/carp_esense_package/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.1
+
+* register the 1.x `ESenseDevice` device type as a `fromJson` alias, for backwards compatibility with studies created on CAMS 1.x (protocol API level < 2.0)
+
 ## 2.0.0
 
 * upgrade to CARP Core and CAMS API level 2.0.0

--- a/packages/carp_esense_package/pubspec.yaml
+++ b/packages/carp_esense_package/pubspec.yaml
@@ -1,5 +1,5 @@
 name: carp_esense_package
-version: 2.0.0
+version: 2.0.1
 description: The CARP eSense sampling package. Samples sensor and device events from the eSense ear plug device.
 homepage: https://github.com/cph-cachet/carp.sensing-flutter
 repository: https://github.com/cph-cachet/carp.sensing-flutter/tree/main/packages/carp_esense_package

--- a/packages/carp_health_package/CHANGELOG.md
+++ b/packages/carp_health_package/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.1
+
+* register the 1.x `HealthService` device type as a `fromJson` alias, for backwards compatibility with studies created on CAMS 1.x (protocol API level < 2.0)
+
 ## 4.0.0
 
 * upgrade to CARP Core and CAMS API level 2.0.0

--- a/packages/carp_health_package/pubspec.yaml
+++ b/packages/carp_health_package/pubspec.yaml
@@ -1,5 +1,5 @@
 name: carp_health_package
-version: 4.0.0
+version: 4.0.1
 description: CARP health sampling package. Samples health data from Apple Health or Google Fit.
 homepage: https://github.com/cph-cachet/carp.sensing-flutter
 repository: https://github.com/cph-cachet/carp.sensing-flutter/tree/main/packages/carp_health_package

--- a/packages/carp_movesense_package/CHANGELOG.md
+++ b/packages/carp_movesense_package/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.1
+
+* register the 1.x `MovesenseDevice` device type as a `fromJson` alias, for backwards compatibility with studies created on CAMS 1.x (protocol API level < 2.0)
+
 ## 2.0.0
 
 * upgrade to CARP Core and CAMS API level 2.0.0

--- a/packages/carp_movesense_package/example/ios/Flutter/Flutter.podspec
+++ b/packages/carp_movesense_package/example/ios/Flutter/Flutter.podspec
@@ -1,0 +1,18 @@
+#
+# This podspec is NOT to be published. It is only used as a local source!
+# This is a generated file; do not edit or check into version control.
+#
+
+Pod::Spec.new do |s|
+  s.name             = 'Flutter'
+  s.version          = '1.0.0'
+  s.summary          = 'A UI toolkit for beautiful and fast apps.'
+  s.homepage         = 'https://flutter.dev'
+  s.license          = { :type => 'BSD' }
+  s.author           = { 'Flutter Dev Team' => 'flutter-dev@googlegroups.com' }
+  s.source           = { :git => 'https://github.com/flutter/engine', :tag => s.version.to_s }
+  s.ios.deployment_target = '13.0'
+  # Framework linking is handled by Flutter tooling, not CocoaPods.
+  # Add a placeholder to satisfy `s.dependency 'Flutter'` plugin podspecs.
+  s.vendored_frameworks = 'path/to/nothing'
+end

--- a/packages/carp_movesense_package/pubspec.yaml
+++ b/packages/carp_movesense_package/pubspec.yaml
@@ -1,5 +1,5 @@
 name: carp_movesense_package
-version: 2.0.0
+version: 2.0.1
 description: The CARP Movesense sampling package. Samples sensor data from the Movesense MD and ACTIVE (HR+, HR2) devices.
 homepage: https://github.com/cph-cachet/carp.sensing-flutter
 repository: https://github.com/cph-cachet/carp.sensing-flutter/tree/main/packages/carp_movesense_package

--- a/packages/carp_movisens_package/CHANGELOG.md
+++ b/packages/carp_movisens_package/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.1
+
+* register the 1.x `MovisensDevice` device type as a `fromJson` alias, for backwards compatibility with studies created on CAMS 1.x (protocol API level < 2.0)
+
 ## 2.0.0
 
 * upgrade to CARP Core and CAMS API level 2.0.0

--- a/packages/carp_movisens_package/pubspec.yaml
+++ b/packages/carp_movisens_package/pubspec.yaml
@@ -1,5 +1,5 @@
 name: carp_movisens_package
-version: 2.0.0
+version: 2.0.1
 description: CARP Movisens sampling package. Samples movement, activity, HRV, MET-level, and ECG for the Movisens Move4 and EcgMove4 devices
 homepage: https://github.com/cph-cachet/carp.sensing-flutter
 repository: https://github.com/cph-cachet/carp.sensing-flutter/tree/main/packages/carp_movisens_package

--- a/packages/carp_polar_package/CHANGELOG.md
+++ b/packages/carp_polar_package/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.1
+
+* register the 1.x `PolarDevice` device type as a `fromJson` alias, for backwards compatibility with studies created on CAMS 1.x (protocol API level < 2.0)
+
 ## 2.0.0
 
 * upgrade to CARP Core and CAMS API level 2.0.0

--- a/packages/carp_polar_package/pubspec.yaml
+++ b/packages/carp_polar_package/pubspec.yaml
@@ -1,5 +1,5 @@
 name: carp_polar_package
-version: 2.0.0
+version: 2.0.1
 description: The CARP Polar sampling package. Samples sensor data from the Polar H9, H10, and Verity Sense devices.
 homepage: https://github.com/cph-cachet/carp.sensing-flutter
 repository: https://github.com/cph-cachet/carp.sensing-flutter/tree/main/packages/carp_polar_package


### PR DESCRIPTION
Follow-up to #579 — version bumps and changelog notes so the CAMS 1.x backwards-compatibility fixes can be released to pub.dev.

## Packages to publish

PR #579 changed `lib/` in seven packages, so all seven need a new release:

| Package | Version | Notes |
|---|---|---|
| `carp_mobile_sensing` | 2.1.1 → **2.1.2** | 1.x device-namespace aliases, `stepcount` restore, BLE / `deployed` / `status` deserialization tolerance, and the SQLite 1.x → 2.x DB migration |
| `carp_context_package` | 2.0.0 → **2.0.1** | 1.x aliases for `LocationService`, `WeatherService`, `AirQualityService` |
| `carp_esense_package` | 2.0.0 → **2.0.1** | 1.x alias for `ESenseDevice` |
| `carp_health_package` | 4.0.0 → **4.0.1** | 1.x alias for `HealthService` |
| `carp_movesense_package` | 2.0.0 → **2.0.1** | 1.x alias for `MovesenseDevice` |
| `carp_movisens_package` | 2.0.0 → **2.0.1** | 1.x alias for `MovisensDevice` |
| `carp_polar_package` | 2.0.0 → **2.0.1** | 1.x alias for `PolarDevice` |

All patch bumps, since these are backwards-compatibility bug fixes.

## Publish order

Publish `carp_mobile_sensing` 2.1.2 first, then the six device packages in any order. Each device package already constrains `carp_mobile_sensing: ^2.0.0`, which 2.1.2 satisfies, so no dependency-constraint changes are needed.
