### PR TITLE
fix(cams): remove ANSI color codes from log output

### DIFF
--- a/carp_mobile_sensing/lib/infrastructure/services/logging.dart
+++ b/carp_mobile_sensing/lib/infrastructure/services/logging.dart
@@ -10,18 +10,18 @@ part of '../../infrastructure.dart';
 /// Add an information messages to the system log.
 void info(String message) =>
     (Settings().debugLevel.index >= DebugLevel.info.index)
-    ? debugPrint('\x1B[32m[CAMS INFO]\x1B[0m $message')
+    ? debugPrint('[CAMS INFO] $message')
     : 0;
 
 /// Add a warning messages to the system log.
 void warning(String message) =>
     (Settings().debugLevel.index >= DebugLevel.warning.index)
-    ? debugPrint('\x1B[31m[CAMS WARNING]\x1B[0m $message')
+    ? debugPrint('[CAMS WARNING] $message')
     : 0;
 
 /// Add a debug messages to the system log.
 /// Only logged if the Flutter app is in debug mode (kDebugMode).
 void debug(String message) =>
     (kDebugMode && Settings().debugLevel.index >= DebugLevel.debug.index)
-    ? debugPrint('\x1B[35m[CAMS DEBUG]\x1B[0m $message')
+    ? debugPrint('[CAMS DEBUG] $message')
     : 0;


### PR DESCRIPTION
## What

Removes the ANSI escape codes (`\x1B[32m`, `\x1B[31m`, `\x1B[35m`) from the `info`/`warning`/`debug` helpers in `logging.dart`.

## Why

The VSCode Debug Console does not render ANSI color codes. Instead of colored log tags, the raw escape sequences (e.g. `[32m[CAMS INFO][0m`) show up in the console and clutter the output. Since there is no color benefit in that console, there is not much point in emitting the codes — so we drop them and print plain `[CAMS INFO]` / `[CAMS WARNING]` / `[CAMS DEBUG]` tags instead.