### PR TITLE
fix: health connect permission setup, probe collision, and battery read

### DIFF
--- a/carp_mobile_sensing/lib/runtime/device_manager/device_managers.dart
+++ b/carp_mobile_sensing/lib/runtime/device_manager/device_managers.dart
@@ -164,9 +164,14 @@ class SmartphoneDeviceManager
   @override
   void onConfigure() {
     // listen to the battery
-    _battery.onBatteryStateChanged.listen(
-      (state) async => _batteryLevel = await _battery.batteryLevel,
-    );
+    _battery.onBatteryStateChanged.listen((state) async {
+      try {
+        _batteryLevel = await _battery.batteryLevel;
+      } catch (error) {
+        // Battery info is unavailable on some platforms (e.g. the iOS simulator).
+        warning('$runtimeType - could not read battery level: $error');
+      }
+    });
 
     // find the supported data types
     for (var package in SamplingPackageRegistry().packages) {

--- a/carp_mobile_sensing/lib/runtime/executors/probes.dart
+++ b/carp_mobile_sensing/lib/runtime/executors/probes.dart
@@ -131,6 +131,16 @@ abstract class Probe extends AbstractExecutor<Measure> {
     return granted;
   }
 
+  /// Whether this probe is allowed to run.
+  ///
+  /// On Android the [SmartphoneStudyController] requests all deployment
+  /// permissions in a single batch ([SmartphoneStudyController.askForAllPermissions]),
+  /// so probes only check - requesting again here would collide, as
+  /// permission_handler forbids concurrent requests. On iOS permissions are
+  /// requested automatically when a resource is accessed.
+  Future<bool> hasRequiredPermissions() async =>
+      Platform.isIOS ? true : await arePermissionsGranted();
+
   // default no-op implementation of callback methods below
 
   @override
@@ -159,7 +169,7 @@ class StubProbe extends Probe {}
 abstract class MeasurementProbe extends Probe {
   @override
   Future<bool> onResume() async {
-    if (await requestPermissions()) {
+    if (await hasRequiredPermissions()) {
       getMeasurement().then(
         (measurement) {
           if (measurement != null) addMeasurement(measurement);
@@ -196,7 +206,7 @@ abstract class IntervalProbe extends MeasurementProbe {
 
   @override
   Future<bool> onResume() async {
-    if (await requestPermissions()) {
+    if (await hasRequiredPermissions()) {
       Duration? interval = samplingConfiguration?.interval;
       if (interval != null) {
         _timer ??= Timer.periodic(interval, (_) async {
@@ -248,7 +258,7 @@ abstract class StreamProbe extends Probe {
 
   @override
   Future<bool> onResume() async {
-    if (await requestPermissions()) {
+    if (await hasRequiredPermissions()) {
       _stream ??= stream;
       if (_stream == null) {
         warning(
@@ -304,7 +314,7 @@ abstract class PeriodicStreamProbe extends StreamProbe {
 
   @override
   Future<bool> onResume() async {
-    if (await requestPermissions()) {
+    if (await hasRequiredPermissions()) {
       if (stream == null) {
         warning(
           "Trying to start the stream probe '$runtimeType' which does not provide a measurement stream. "
@@ -364,7 +374,7 @@ abstract class BufferingPeriodicProbe extends MeasurementProbe {
 
   @override
   Future<bool> onResume() async {
-    if (await requestPermissions()) {
+    if (await hasRequiredPermissions()) {
       Duration? interval = samplingConfiguration?.interval;
       Duration? duration = samplingConfiguration?.duration;
       if (interval != null && duration != null) {
@@ -456,7 +466,7 @@ abstract class BufferingIntervalStreamProbe extends StreamProbe {
 
   @override
   Future<bool> onResume() async {
-    if (await requestPermissions()) {
+    if (await hasRequiredPermissions()) {
       Duration? interval = samplingConfiguration?.interval;
       if (interval != null) {
         _bufferingStreamSubscription = bufferingStream.listen(
@@ -545,7 +555,7 @@ abstract class BufferingPeriodicStreamProbe extends PeriodicStreamProbe {
 
   @override
   Future<bool> onResume() async {
-    if (await requestPermissions()) {
+    if (await hasRequiredPermissions()) {
       Duration? interval = samplingConfiguration?.interval;
       Duration? duration = samplingConfiguration?.duration;
       if (interval != null && duration != null) {

--- a/carp_mobile_sensing/pubspec.yaml
+++ b/carp_mobile_sensing/pubspec.yaml
@@ -1,5 +1,5 @@
 name: carp_mobile_sensing
-version: 2.1.3
+version: 2.1.4
 description: Mobile Sensing Framework for Flutter. A software framework for collecting sensor data from the phone and attached wearable devices via probes. Can be extended.
 
 # Note that the following URLs to GitHub should use the old 'cph-cachet' name.

--- a/packages/carp_health_package/lib/health_service_manager.dart
+++ b/packages/carp_health_package/lib/health_service_manager.dart
@@ -44,10 +44,10 @@ class HealthServiceManager
             : "Google Health Connect"
       : 'N/A';
 
-  final List<HealthDataType> _types = [];
+  final Set<HealthDataType> _types = {};
 
   /// Which health data types should this service access.
-  List<HealthDataType> get types => _types.toSet().toList();
+  List<HealthDataType> get types => _types.toList();
 
   /// Add a set of health [types] this service should access.
   void addTypes(List<HealthDataType> types) {
@@ -63,6 +63,11 @@ class HealthServiceManager
   @override
   void onConfigure() {
     Health().configure();
+
+    // Gather the health types from the device's default sampling configuration.
+    final config =
+        configuration?.defaultSamplingConfiguration?[HealthSamplingPackage.HEALTH];
+    if (config is HealthSamplingConfiguration) addTypes(config.healthDataTypes);
 
     if (Platform.isAndroid) {
       var sdkLevel = int.parse(DeviceInfoService().sdk ?? '-1');
@@ -133,6 +138,8 @@ class HealthServiceManager
   @override
   Future<bool> onHasPermissions() async {
     if (_hasPermissions) return true;
+    // No registered types yet must not count as "granted".
+    if (types.isEmpty) return false;
     _hasPermissions = await hasHealthPermissions(types);
     // if permissions are granted, we can consider the service as connected, otherwise disconnected.
     status = _hasPermissions

--- a/packages/carp_health_package/pubspec.yaml
+++ b/packages/carp_health_package/pubspec.yaml
@@ -1,5 +1,5 @@
 name: carp_health_package
-version: 4.0.1
+version: 4.0.2
 description: CARP health sampling package. Samples health data from Apple Health or Google Fit.
 homepage: https://github.com/cph-cachet/carp.sensing-flutter
 repository: https://github.com/cph-cachet/carp.sensing-flutter/tree/main/packages/carp_health_package


### PR DESCRIPTION
## What changed

- **carp_health_package — Health Connect permission setup.** `HealthServiceManager` now gathers its health data types from the device's `defaultSamplingConfiguration` in `onConfigure`, and no longer treats an empty type list as "granted". *Why:* the service otherwise had no types until a health probe initialized (deferred for app-tasks), so it requested no Health Connect permissions (the permission sheet never appeared) and falsely reported itself connected.

- **carp_mobile_sensing — probe permission collision.** Probes only *check* permissions on resume instead of *requesting* them; the study controller already requests all deployment permissions in one batch. *Why:* concurrent per-probe requests collided (`permission_handler` forbids concurrent requests), spamming `Unhandled Exception` errors and leaving `activity_recognition` ungranted.

- **carp_mobile_sensing — battery read.** Battery-level reads are wrapped in try/catch. *Why:* on some platforms (e.g. the iOS simulator) the read throws, surfacing as an unhandled error during sensing setup.

Versions bumped: `carp_mobile_sensing` 2.1.3 → 2.1.4, `carp_health_package` 4.0.1 → 4.0.2.
