### PR TITLE
fix(context): configure location service on connect, not configure

### DIFF
--- a/carp_mobile_sensing/pubspec.yaml
+++ b/carp_mobile_sensing/pubspec.yaml
@@ -1,5 +1,5 @@
 name: carp_mobile_sensing
-version: 2.1.5
+version: 2.1.6
 description: Mobile Sensing Framework for Flutter. A software framework for collecting sensor data from the phone and attached wearable devices via probes. Can be extended.
 
 # Note that the following URLs to GitHub should use the old 'cph-cachet' name.

--- a/packages/carp_context_package/lib/src/location/location_services.dart
+++ b/packages/carp_context_package/lib/src/location/location_services.dart
@@ -85,12 +85,10 @@ class LocationServiceManager extends ContextServiceManager<LocationService> {
     : super(LocationService.DEVICE_TYPE, configuration: configuration);
 
   @override
-  void onConfigure() => manager.configure(configuration!);
-
-  @override
-  Future<DeviceStatus> onConnect() async => manager.enabled
-      ? DeviceStatus.connected
-      : (await manager.enable().then((_) => DeviceStatus.connected));
+  Future<DeviceStatus> onConnect() async {
+    await manager.configure(configuration!);
+    return manager.enabled ? DeviceStatus.connected : DeviceStatus.disconnected;
+  }
 
   @override
   Future<bool> onHasPermissions() async => await manager.hasPermission();

--- a/packages/carp_context_package/lib/src/location_manager.dart
+++ b/packages/carp_context_package/lib/src/location_manager.dart
@@ -101,14 +101,6 @@ class LocationManager {
   /// This method is, however, **NOT** used by this context sampling package, since
   /// handling of permissions should be taken care of on an app level.
   Future<PermissionStatus> requestPermission() async {
-    // Fast out if not configured
-    if (!configured) {
-      warning(
-        '$runtimeType - is not configured. '
-        "Call 'configure' before requesting permission.",
-      );
-      return PermissionStatus.denied;
-    }
     debug('$runtimeType - Requesting permission to access location...');
 
     var permissionGranted = await _provider.hasPermission();


### PR DESCRIPTION
## Problem

Tapping a location-based online service (Location, and by extension Weather / Air Quality) never showed the OS location permission dialog, and the service never connected.

Root cause is a deadlock between configuration and permission:

- `LocationServiceManager.onConfigure()` called `manager.configure()`, which enables the OS location service and runs `changeSettings()`. That is heavy, async, permission-dependent work fired **un-awaited** from a `void onConfigure()` hook — which the base `DeviceManager` contract explicitly requires to be lightweight ("must not be doing a lot of work on startup").
- On Android, `changeSettings()` throws without location permission, so `LocationManager._configured` never became `true`.
- `requestPermission()` had a `if (!configured) return denied;` fast-out, so it refused to show the dialog until configured.

Result: configuration needed the permission, and the permission request refused to run until configured — the dialog was never shown.

## Fix

- Move configuration from `onConfigure()` to `onConnect()`. `connect()` only calls `onConnect()` after the `hasPermissions()` gate, so permission is always granted before `configure()` runs — `changeSettings()` no longer throws and `_configured` becomes `true` reliably. It is also awaited, so failures surface instead of being swallowed.
- `onConfigure()` is removed (inherits the empty `ContextServiceManager.onConfigure`), honoring the lightweight-init contract.
- Drop the `!configured` fast-out in `requestPermission()`; requesting the OS permission does not require prior configuration, and permission must now precede it.