### PR TITLE
fix(devices): make Polar and Movesense BLE connections reliable

### DIFF
--- a/carp_mobile_sensing/CHANGELOG.md
+++ b/carp_mobile_sensing/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * resume a connectable device's task control executors when it connects after the study has started - previously they stayed paused and the device never sampled
 * request location permission for BLE devices on Android, which is required for BLE scanning to return any results
+* cancel the previous subscription when a [StreamProbe] is resumed, so resuming an already resumed probe no longer orphans a subscription that keeps delivering and collects every measurement once per resume
 
 ## 2.1.3
 

--- a/carp_mobile_sensing/CHANGELOG.md
+++ b/carp_mobile_sensing/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.1.7
+
+* resume a connectable device's task control executors when it connects after the study has started - previously they stayed paused and the device never sampled
+* request location permission for BLE devices on Android, which is required for BLE scanning to return any results
+
 ## 2.1.3
 
 * Update `screen_state` plugin to 5.0.1

--- a/carp_mobile_sensing/lib/runtime/device_manager/device_manager.dart
+++ b/carp_mobile_sensing/lib/runtime/device_manager/device_manager.dart
@@ -159,13 +159,8 @@ abstract class DeviceManager<
     _registration = registration;
     onConfigure();
 
-    // Listen to status events and when this device is connecting, disconnecting,
-    // or reconnected, start, stop, or restart sampling.
-    //
-    // [start] on [connected] handles the case where a connectable device (e.g.
-    // a BLE sensor) connects *after* the study is already running: its task
-    // control executors were paused at study resume (device not yet connected),
-    // and nothing else resumes them once the device connects.
+    // A device connecting after the study has started has its executors paused,
+    // and nothing else resumes them.
     statusEvents
         .where((status) => status == DeviceStatus.connected)
         .listen((_) => start());

--- a/carp_mobile_sensing/lib/runtime/device_manager/device_manager.dart
+++ b/carp_mobile_sensing/lib/runtime/device_manager/device_manager.dart
@@ -159,8 +159,16 @@ abstract class DeviceManager<
     _registration = registration;
     onConfigure();
 
-    // Listen to status events and when this device is disconnecting or reconnected,
-    // stop or restart sampling.
+    // Listen to status events and when this device is connecting, disconnecting,
+    // or reconnected, start, stop, or restart sampling.
+    //
+    // [start] on [connected] handles the case where a connectable device (e.g.
+    // a BLE sensor) connects *after* the study is already running: its task
+    // control executors were paused at study resume (device not yet connected),
+    // and nothing else resumes them once the device connects.
+    statusEvents
+        .where((status) => status == DeviceStatus.connected)
+        .listen((_) => start());
     statusEvents
         .where((status) => status == DeviceStatus.disconnecting)
         .listen((_) => isDisconnecting());

--- a/carp_mobile_sensing/lib/runtime/device_manager/device_managers.dart
+++ b/carp_mobile_sensing/lib/runtime/device_manager/device_managers.dart
@@ -124,7 +124,6 @@ abstract class BLEDeviceManager<
     if (Platform.isAndroid) {
       await Permission.bluetoothScan.request();
       await Permission.bluetoothConnect.request();
-      // BLE scanning on Android also requires location permission.
       await Permission.locationWhenInUse.request();
     }
     if (Platform.isIOS) {

--- a/carp_mobile_sensing/lib/runtime/device_manager/device_managers.dart
+++ b/carp_mobile_sensing/lib/runtime/device_manager/device_managers.dart
@@ -109,7 +109,9 @@ abstract class BLEDeviceManager<
   @mustCallSuper
   Future<bool> onHasPermissions() async => (Platform.isAndroid)
       ? await Permission.bluetoothConnect.isGranted &&
-            await Permission.bluetoothScan.isGranted
+            await Permission.bluetoothScan.isGranted &&
+            // BLE scanning on Android also requires location permission.
+            await Permission.locationWhenInUse.isGranted
       // : (Platform.isIOS)
       //     ? await Permission.bluetooth.isGranted
       // for some reason it seems like Permission.bluetooth.isGranted always
@@ -122,6 +124,8 @@ abstract class BLEDeviceManager<
     if (Platform.isAndroid) {
       await Permission.bluetoothScan.request();
       await Permission.bluetoothConnect.request();
+      // BLE scanning on Android also requires location permission.
+      await Permission.locationWhenInUse.request();
     }
     if (Platform.isIOS) {
       await Permission.bluetooth.request();

--- a/carp_mobile_sensing/lib/runtime/executors/probes.dart
+++ b/carp_mobile_sensing/lib/runtime/executors/probes.dart
@@ -267,10 +267,8 @@ abstract class StreamProbe extends Probe {
         );
         return false;
       } else {
-        // Cancel any previous subscription before listening again. Resuming an
-        // already resumed probe would otherwise orphan the old subscription,
-        // which keeps delivering, and every measurement would be collected
-        // once per resume.
+        // Resuming an already resumed probe would otherwise orphan the old
+        // subscription, which keeps delivering.
         await _subscription?.cancel();
         _subscription = _stream?.listen(
           _onData,

--- a/carp_mobile_sensing/lib/runtime/executors/probes.dart
+++ b/carp_mobile_sensing/lib/runtime/executors/probes.dart
@@ -267,6 +267,11 @@ abstract class StreamProbe extends Probe {
         );
         return false;
       } else {
+        // Cancel any previous subscription before listening again. Resuming an
+        // already resumed probe would otherwise orphan the old subscription,
+        // which keeps delivering, and every measurement would be collected
+        // once per resume.
+        await _subscription?.cancel();
         _subscription = _stream?.listen(
           _onData,
           onError: _onError,

--- a/carp_mobile_sensing/pubspec.yaml
+++ b/carp_mobile_sensing/pubspec.yaml
@@ -1,5 +1,5 @@
 name: carp_mobile_sensing
-version: 2.1.6
+version: 2.1.7
 description: Mobile Sensing Framework for Flutter. A software framework for collecting sensor data from the phone and attached wearable devices via probes. Can be extended.
 
 # Note that the following URLs to GitHub should use the old 'cph-cachet' name.

--- a/carp_mobile_sensing/test/probes_test.dart
+++ b/carp_mobile_sensing/test/probes_test.dart
@@ -4,7 +4,6 @@ import 'package:carp_core/carp_core.dart' hide Smartphone;
 import 'package:carp_mobile_sensing/carp_mobile_sensing.dart';
 import 'package:test/test.dart';
 
-/// A [StreamProbe] collecting from a stream that is controlled by the test.
 class _TestStreamProbe extends StreamProbe {
   final controller = StreamController<Measurement>.broadcast();
 
@@ -29,9 +28,6 @@ void main() {
       probe.measurements.listen(collected.add);
 
       await probe.onResume();
-      // Resuming again must cancel the previous subscription. Overwriting it
-      // would orphan a subscription that keeps delivering, and every measurement
-      // would be collected once per resume.
       await probe.onResume();
 
       probe.controller.add(Measurement.fromData(FileData(filename: 'test')));

--- a/carp_mobile_sensing/test/probes_test.dart
+++ b/carp_mobile_sensing/test/probes_test.dart
@@ -1,0 +1,46 @@
+import 'dart:async';
+
+import 'package:carp_core/carp_core.dart' hide Smartphone;
+import 'package:carp_mobile_sensing/carp_mobile_sensing.dart';
+import 'package:test/test.dart';
+
+/// A [StreamProbe] collecting from a stream that is controlled by the test.
+class _TestStreamProbe extends StreamProbe {
+  final controller = StreamController<Measurement>.broadcast();
+
+  @override
+  Future<bool> hasRequiredPermissions() async => true;
+
+  @override
+  Stream<Measurement> get stream => controller.stream;
+}
+
+void main() {
+  setUp(() {
+    CarpMobileSensing.ensureInitialized();
+  });
+
+  test(
+    'Resuming a resumed stream probe collects each measurement once',
+    () async {
+      final probe = _TestStreamProbe();
+
+      final collected = <Measurement>[];
+      probe.measurements.listen(collected.add);
+
+      await probe.onResume();
+      // Resuming again must cancel the previous subscription. Overwriting it
+      // would orphan a subscription that keeps delivering, and every measurement
+      // would be collected once per resume.
+      await probe.onResume();
+
+      probe.controller.add(Measurement.fromData(FileData(filename: 'test')));
+      await Future.delayed(const Duration(milliseconds: 100));
+
+      expect(collected.length, 1);
+
+      await probe.onPause();
+      await probe.controller.close();
+    },
+  );
+}

--- a/packages/carp_movesense_package/CHANGELOG.md
+++ b/packages/carp_movesense_package/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.2
+
+* disconnect from MDS when a connection attempt fails, so the native SDK stops auto-retrying in the background and the device settles as disconnected
+
 ## 2.0.1
 
 * register the 1.x `MovesenseDevice` device type as a `fromJson` alias, for backwards compatibility with studies created on CAMS 1.x (protocol API level < 2.0)

--- a/packages/carp_movesense_package/lib/movesense_device_manager.dart
+++ b/packages/carp_movesense_package/lib/movesense_device_manager.dart
@@ -177,11 +177,8 @@ class MovesenseDeviceManager
           status = DeviceStatus.connected;
         } else {
           warning("$runtimeType - Error in connecting to device: $error");
-          // Tear down the half-open MDS/GATT connection so the native SDK stops
-          // auto-retrying it in the background (e.g. when the peripheral has a
-          // stale bond and exposes no Whiteboard service, or the address is not
-          // a Movesense device at all). Without this the connection lingers in
-          // an "in-between" state and retries every few seconds.
+          // Tear down the half-open connection, or the native SDK keeps
+          // retrying it in the background.
           Mds.disconnect(bleAddress!);
           status = DeviceStatus.disconnected;
         }

--- a/packages/carp_movesense_package/lib/movesense_device_manager.dart
+++ b/packages/carp_movesense_package/lib/movesense_device_manager.dart
@@ -177,8 +177,13 @@ class MovesenseDeviceManager
           status = DeviceStatus.connected;
         } else {
           warning("$runtimeType - Error in connecting to device: $error");
-          // we return status to be initialized so that the user has a chance to reconnect
-          status = DeviceStatus.configured;
+          // Tear down the half-open MDS/GATT connection so the native SDK stops
+          // auto-retrying it in the background (e.g. when the peripheral has a
+          // stale bond and exposes no Whiteboard service, or the address is not
+          // a Movesense device at all). Without this the connection lingers in
+          // an "in-between" state and retries every few seconds.
+          Mds.disconnect(bleAddress!);
+          status = DeviceStatus.disconnected;
         }
       },
       // onBleConnected

--- a/packages/carp_movesense_package/pubspec.yaml
+++ b/packages/carp_movesense_package/pubspec.yaml
@@ -1,5 +1,5 @@
 name: carp_movesense_package
-version: 2.0.1
+version: 2.0.2
 description: The CARP Movesense sampling package. Samples sensor data from the Movesense MD and ACTIVE (HR+, HR2) devices.
 homepage: https://github.com/cph-cachet/carp.sensing-flutter
 repository: https://github.com/cph-cachet/carp.sensing-flutter/tree/main/packages/carp_movesense_package

--- a/packages/carp_polar_package/CHANGELOG.md
+++ b/packages/carp_polar_package/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * discover data types from both the online streaming (PMD) and the HR service SDK features, so devices that only deliver HR via the standard BLE HR service (e.g. Verity Sense) report their supported types
 * clear the discovered data types on disconnect
+* clean up the event listeners when a connection attempt fails, so a later attempt does not stack subscriptions on a half-connected device
+* await the cancellation of the event listeners when disconnecting, so the disconnect emitted by the SDK is not handled by the listeners being torn down
 
 ## 2.0.1
 

--- a/packages/carp_polar_package/CHANGELOG.md
+++ b/packages/carp_polar_package/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.2
+
+* discover data types from both the online streaming (PMD) and the HR service SDK features, so devices that only deliver HR via the standard BLE HR service (e.g. Verity Sense) report their supported types
+* clear the discovered data types on disconnect
+
 ## 2.0.1
 
 * register the 1.x `PolarDevice` device type as a `fromJson` alias, for backwards compatibility with studies created on CAMS 1.x (protocol API level < 2.0)

--- a/packages/carp_polar_package/lib/polar_device_manager.dart
+++ b/packages/carp_polar_package/lib/polar_device_manager.dart
@@ -243,21 +243,35 @@ class PolarDeviceManager
         rssi = null;
       });
 
-      // find out what data types the connected Polar device supports in streaming mode,
-      // and mark the device as fully connected when the types are available
-      polar.sdkFeatureReady
-          .firstWhere(
-            (event) =>
-                event.identifier == polarIdentifier &&
-                event.feature == PolarSdkFeature.onlineStreaming,
-          )
-          .then((_) {
-            polar.getAvailableOnlineStreamDataTypes(polarIdentifier!).then((
-              availableDataTypes,
-            ) {
-              dataTypes = availableDataTypes.toList();
-              status = DeviceStatus.connected;
-            });
+      // Find out what data types the connected Polar device supports and mark
+      // it as connected once any are available.
+      //
+      // Capabilities come from two independent SDK features that may become
+      // ready at different times (or only one of them):
+      //  * onlineStreaming - the Polar Measurement Data (PMD) service (ECG,
+      //    ACC, PPG, PPI, ...), available on H10, Verity Sense, etc.
+      //  * hr - the standard BLE HR service, which delivers HR on devices that
+      //    do not expose HR via PMD (e.g. Verity Sense).
+      // So we listen for each feature separately rather than gating on
+      // onlineStreaming alone (which would leave HR-only devices stuck).
+      _sdkFeatureSubscription = polar.sdkFeatureReady
+          .where((event) => event.identifier == polarIdentifier)
+          .listen((event) async {
+            Set<PolarDataType> available = {};
+            if (event.feature == PolarSdkFeature.onlineStreaming) {
+              available = await polar.getAvailableOnlineStreamDataTypes(
+                polarIdentifier!,
+              );
+            } else if (event.feature == PolarSdkFeature.hr) {
+              available = await polar.getAvailableHrServiceDataTypes(
+                polarIdentifier!,
+              );
+            } else {
+              return;
+            }
+
+            dataTypes = {...?dataTypes, ...available}.toList();
+            status = DeviceStatus.connected;
           });
 
       // now finally, start connecting to the device based on its identifier
@@ -276,6 +290,7 @@ class PolarDeviceManager
     if (polarIdentifier == null) return false;
 
     _batteryLevel = null;
+    dataTypes = null;
     _batterySubscription?.cancel();
     _connectingSubscription?.cancel();
     _connectedSubscription?.cancel();

--- a/packages/carp_polar_package/lib/polar_device_manager.dart
+++ b/packages/carp_polar_package/lib/polar_device_manager.dart
@@ -281,6 +281,9 @@ class PolarDeviceManager
       warning(
         "$runtimeType - could not connect to device of type '$deviceType' and id '$polarIdentifier' - error: $error",
       );
+      // Clean up the listeners set up above as well, so a later connect attempt
+      // does not stack subscriptions on a half-connected device.
+      await onDisconnect();
       return DeviceStatus.disconnected;
     }
   }
@@ -291,11 +294,15 @@ class PolarDeviceManager
 
     _batteryLevel = null;
     dataTypes = null;
-    _batterySubscription?.cancel();
-    _connectingSubscription?.cancel();
-    _connectedSubscription?.cancel();
-    _disconnectedSubscription?.cancel();
-    _sdkFeatureSubscription?.cancel();
+    // Await the cancellations - disconnecting below makes the SDK emit a
+    // disconnect event, which must not reach these listeners anymore.
+    await Future.wait([
+      ?_batterySubscription?.cancel(),
+      ?_connectingSubscription?.cancel(),
+      ?_connectedSubscription?.cancel(),
+      ?_disconnectedSubscription?.cancel(),
+      ?_sdkFeatureSubscription?.cancel(),
+    ]);
 
     await polar.disconnectFromDevice(polarIdentifier!);
 

--- a/packages/carp_polar_package/lib/polar_device_manager.dart
+++ b/packages/carp_polar_package/lib/polar_device_manager.dart
@@ -243,17 +243,9 @@ class PolarDeviceManager
         rssi = null;
       });
 
-      // Find out what data types the connected Polar device supports and mark
-      // it as connected once any are available.
-      //
-      // Capabilities come from two independent SDK features that may become
-      // ready at different times (or only one of them):
-      //  * onlineStreaming - the Polar Measurement Data (PMD) service (ECG,
-      //    ACC, PPG, PPI, ...), available on H10, Verity Sense, etc.
-      //  * hr - the standard BLE HR service, which delivers HR on devices that
-      //    do not expose HR via PMD (e.g. Verity Sense).
-      // So we listen for each feature separately rather than gating on
-      // onlineStreaming alone (which would leave HR-only devices stuck).
+      // Data types come from two SDK features that become ready independently -
+      // a device delivering HR over the standard BLE HR service only (e.g.
+      // Verity Sense) never reports the online streaming (PMD) one.
       _sdkFeatureSubscription = polar.sdkFeatureReady
           .where((event) => event.identifier == polarIdentifier)
           .listen((event) async {
@@ -281,8 +273,8 @@ class PolarDeviceManager
       warning(
         "$runtimeType - could not connect to device of type '$deviceType' and id '$polarIdentifier' - error: $error",
       );
-      // Clean up the listeners set up above as well, so a later connect attempt
-      // does not stack subscriptions on a half-connected device.
+      // Clean up the listeners set up above, so a later attempt does not stack
+      // subscriptions on a half-connected device.
       await onDisconnect();
       return DeviceStatus.disconnected;
     }
@@ -294,8 +286,8 @@ class PolarDeviceManager
 
     _batteryLevel = null;
     dataTypes = null;
-    // Await the cancellations - disconnecting below makes the SDK emit a
-    // disconnect event, which must not reach these listeners anymore.
+    // Disconnecting below makes the SDK emit a disconnect event, which must not
+    // reach these listeners anymore.
     await Future.wait([
       ?_batterySubscription?.cancel(),
       ?_connectingSubscription?.cancel(),

--- a/packages/carp_polar_package/pubspec.yaml
+++ b/packages/carp_polar_package/pubspec.yaml
@@ -1,5 +1,5 @@
 name: carp_polar_package
-version: 2.0.1
+version: 2.0.2
 description: The CARP Polar sampling package. Samples sensor data from the Polar H9, H10, and Verity Sense devices.
 homepage: https://github.com/cph-cachet/carp.sensing-flutter
 repository: https://github.com/cph-cachet/carp.sensing-flutter/tree/main/packages/carp_polar_package


### PR DESCRIPTION
Three independent bugs prevented Polar and Movesense sensors from collecting data. Found while debugging a study app where the Movesense sat in a permanent "in-between" state and the Polar reported *"does not support data type hr"*.

## `carp_mobile_sensing` — 2.1.6 → 2.1.7

**Devices connected after study start never sampled**
A connectable device's task control executors are paused at study resume when the device isn't connected yet. Nothing resumed them once it did connect, so the probes never subscribed. The device manager now calls `start()` on `connected`.

**BLE scanning needs location permission on Android**
`BLEDeviceManager` requested only `bluetoothScan`/`bluetoothConnect`, but Android returns no scan results without location permission. It's now part of the BLE permission set, so apps don't have to request it themselves — this is device-manager knowledge, not app knowledge.

## `carp_movesense_package` — 2.0.1 → 2.0.2

**Stuck between connected and disconnected, retrying forever**
When MDS failed to connect (typically *"device does not have Whiteboard service"*, a symptom of a stale bond), the manager set the status back to `configured` but never tore down the MDS connection. The native SDK kept the GATT link open and retried every few seconds, so the device showed as neither connected nor disconnected and the sensor stopped advertising — making it impossible to find it again in a scan.

It now calls `Mds.disconnect()` and settles as `disconnected`. Safe after an error, since the plugin has already removed the Dart callbacks at that point.

## `carp_polar_package` — 2.0.1 → 2.0.2

**HR-only devices never reported `hr` as a supported type**
Capabilities were read solely from the `onlineStreaming` (PMD) feature. The Verity Sense delivers HR through the *standard BLE HR service* rather than PMD, so `hr` never reached `dataTypes` and `PolarHRProbe` refused to stream with *"does not support data type hr"*.

The two capabilities are independent SDK features that become ready at different times, so the manager now listens for each and merges the results:

| feature | query | devices |
|---|---|---|
| `onlineStreaming` | `getAvailableOnlineStreamDataTypes()` | PMD: ECG, ACC, PPG, PPI (H10, Verity Sense) |
| `hr` | `getAvailableHrServiceDataTypes()` | standard BLE HR service (Verity Sense) |

Gating on `onlineStreaming` alone left HR-only devices stuck in `connecting`. Also clears `dataTypes` on disconnect, which previously persisted stale capabilities across reconnects.

## Testing

- `flutter analyze` on all three packages — no new issues (remaining ones are pre-existing and outside the changed code).
- Verified end-to-end on Android with a Polar Verity Sense and a Movesense ECG sensor: both connect, stream HR, and upload to CAWS.

## Note

The companion app-side change is [carp_study_app#655](https://github.com/carp-dk/carp_study_app/pull/655), which filters the BLE scan list per device type and delegates permission requests to the device manager. It works against the currently published packages; these fixes make the connections reliable.
