### PR TITLE
chore: bump versions for publish

### DIFF
--- a/carp_mobile_sensing/pubspec.yaml
+++ b/carp_mobile_sensing/pubspec.yaml
@@ -1,5 +1,5 @@
 name: carp_mobile_sensing
-version: 2.1.7
+version: 2.1.8
 description: Mobile Sensing Framework for Flutter. A software framework for collecting sensor data from the phone and attached wearable devices via probes. Can be extended.
 
 # Note that the following URLs to GitHub should use the old 'cph-cachet' name.

--- a/packages/carp_context_package/pubspec.yaml
+++ b/packages/carp_context_package/pubspec.yaml
@@ -1,5 +1,5 @@
 name: carp_context_package
-version: 2.0.2
+version: 2.0.3
 description: CARP context sampling package. Samples location, mobility, activity, weather, air-quality, and geofence.
 homepage: https://github.com/cph-cachet/carp.sensing-flutter
 repository: https://github.com/cph-cachet/carp.sensing-flutter/tree/main/packages/carp_context_package

--- a/packages/carp_health_package/pubspec.yaml
+++ b/packages/carp_health_package/pubspec.yaml
@@ -1,5 +1,5 @@
 name: carp_health_package
-version: 4.0.2
+version: 4.0.3
 description: CARP health sampling package. Samples health data from Apple Health or Google Fit.
 homepage: https://github.com/cph-cachet/carp.sensing-flutter
 repository: https://github.com/cph-cachet/carp.sensing-flutter/tree/main/packages/carp_health_package


### PR DESCRIPTION
Version bumps for publish:

- carp_mobile_sensing 2.1.7 → 2.1.8
- carp_context_package 2.0.2 → 2.0.3
- carp_health_package 4.0.2 → 4.0.3